### PR TITLE
Python-http.client fixes

### DIFF
--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -84,13 +84,6 @@ self = module.exports = {
         description: 'How long the request should wait for a response before timing out (milliseconds)'
       },
       {
-        name: 'Follow redirect',
-        id: 'followRedirect',
-        type: 'boolean',
-        default: true,
-        description: 'Automatically follow HTTP redirects'
-      },
-      {
         name: 'Body trim',
         id: 'trimRequestBody',
         type: 'boolean',
@@ -142,7 +135,6 @@ self = module.exports = {
     snippet += 'res = conn.getresponse()\n';
     snippet += 'data = res.read()\n';
     snippet += 'print(data.decode("utf-8"))';
-    snippet += options.followRedirect ? '' : '# Cant handle redirects. Redirects always true\n';
 
     return callback(null, snippet);
   }

--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -127,7 +127,7 @@ self = module.exports = {
     indentation = identity.repeat(options.indentCount);
 
     snippet += 'import http.client\n';
-    snippet += `conn = http.client.HTTPSConnection("${request.url.host.join('.')}"`;
+    snippet += `conn = http.client.HTTPSConnection("${request.url.host ? request.url.host.join('.') : ''}"`;
     snippet += options.requestTimeout !== 0 ? `, timeout = ${options.requestTimeout})\n` : ')\n';
     snippet += parseBody(request.toJSON(), indentation, options.requestBodyTrim);
     snippet += getheaders(request, indentation);

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -122,7 +122,7 @@ function runSnippet (codeSnippet, collection, done) {
   });
 }
 
-describe('Python- Requests converter', function () {
+describe('Python-http.client converter', function () {
   mainCollection.item.forEach(function (item) {
     it(item.name, function (done) {
       var request = new sdk.Request(item.request),
@@ -268,8 +268,7 @@ describe('Python- Requests converter', function () {
       expect(getOptions()[0]).to.have.property('id', 'indentCount');
       expect(getOptions()[1]).to.have.property('id', 'indentType');
       expect(getOptions()[2]).to.have.property('id', 'requestTimeout');
-      expect(getOptions()[3]).to.have.property('id', 'followRedirect');
-      expect(getOptions()[4]).to.have.property('id', 'trimRequestBody');
+      expect(getOptions()[3]).to.have.property('id', 'trimRequestBody');
     });
   });
 

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -202,6 +202,27 @@ describe('Python- Requests converter', function () {
       });
     });
 
+    it('should generate snippet when url is not provied', function () {
+      var request = new sdk.Request({
+        'name': 'test',
+        'request': {
+          'method': 'GET',
+          'header': [],
+          'url': {
+            'raw': ''
+          }
+        },
+        'response': []
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('conn = http.client.HTTPSConnection("")');
+      });
+    });
+
   });
 
   describe('parseBody function', function () {


### PR DESCRIPTION
- Removed followRedirect option as it doesn't handle redirects.
- Fixed a bug which caused snippet generation to fail when request url provided is empty.
- Added failing test for the empty url request.