### PR TITLE
Fixed formdata header bug in python-http.client

### DIFF
--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -22,7 +22,7 @@ function getheaders (request, indentation) {
             `'${sanitize(headerObject[key], 'header')}'`;
     });
     if (requestBodyMode === 'formdata') {
-      headerMap.push(`${indent}'Content-type': 'multipart/form-data; boundary={}'.format(boundary)`);
+      headerMap.push(`${indentation}'Content-type': 'multipart/form-data; boundary={}'.format(boundary)`);
     }
     return `headers = {\n${headerMap.join(',\n')}\n}\n`;
   }

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -223,6 +223,40 @@ describe('Python-http.client converter', function () {
       });
     });
 
+    it('should generate snippet with correct indent when body mode is formdata', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'my-sample-header',
+            'value': 'Lorem ipsum dolor sit amet'
+          }
+        ],
+        'body': {
+          'mode': 'formdata',
+          'formdata': []
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/headers',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'headers'
+          ]
+        }
+      });
+      convert(request, { indentType: 'space', indentCount: 2}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('  \'Content-type\': \'multipart/form-data; boundary={}\'.format(boundary)');
+      });
+    });
+
   });
 
   describe('parseBody function', function () {


### PR DESCRIPTION
Fixed a bug which failed snippet generation when body mode is formdata with non zero headers