### PR TITLE
Addressed unresolved variable encoding issues

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -7,7 +7,10 @@ var sanitize = require('./util').sanitize,
 /**
  *
  * @param {*} urlObject The request sdk request.url object
- * @returns {String} final url string converted from parsing url object
+ * @returns {String} The final string after parsing all the parameters of the url including 
+ * protocol, auth, host, port, path, query, hash
+ * This will be used because the url.toString() method returned the URL with non encoded query string
+ * and hence a manual call is made to getQueryString() method with encode option set as true.
  */
 function getUrlStringfromUrlObject (urlObject) {
   var url = '';

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -1,46 +1,10 @@
 var sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   form = require('./util').form,
   _ = require('./lodash'),
   self;
 
-/**
- *
- * @param {*} urlObject The request sdk request.url object
- * @returns {String} The final string after parsing all the parameters of the url including 
- * protocol, auth, host, port, path, query, hash
- * This will be used because the url.toString() method returned the URL with non encoded query string
- * and hence a manual call is made to getQueryString() method with encode option set as true.
- */
-function getUrlStringfromUrlObject (urlObject) {
-  var url = '';
-  if (urlObject.protocol) {
-    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
-  }
-  if (urlObject.auth && urlObject.auth.user) {
-    url = url + ((urlObject.auth.password) ?
-      // ==> username:password@
-      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
-  }
-  if (urlObject.host) {
-    url += urlObject.getHost();
-  }
-  if (urlObject.port) {
-    url += ':' + urlObject.port.toString();
-  }
-  if (urlObject.path) {
-    url += urlObject.getPath();
-  }
-  if (urlObject.query && urlObject.query.count()) {
-    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
-    queryString && (url += '?' + queryString);
-  }
-  if (urlObject.hash) {
-    url += '#' + urlObject.hash;
-  }
-
-  return url;
-}
 self = module.exports = {
   convert: function (request, options, callback) {
 

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -110,5 +110,42 @@ module.exports = {
       }
     }
     return result;
+  },
+  /**
+ *
+ * @param {*} urlObject The request sdk request.url object
+ * @returns {String} The final string after parsing all the parameters of the url including 
+ * protocol, auth, host, port, path, query, hash
+ * This will be used because the url.toString() method returned the URL with non encoded query string
+ * and hence a manual call is made to getQueryString() method with encode option set as true.
+ */
+getUrlStringfromUrlObject: function (urlObject) {
+  var url = '';
+  if (urlObject.protocol) {
+    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
   }
+  if (urlObject.auth && urlObject.auth.user) {
+    url = url + ((urlObject.auth.password) ?
+      // ==> username:password@
+      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+  }
+  if (urlObject.host) {
+    url += urlObject.getHost();
+  }
+  if (urlObject.port) {
+    url += ':' + urlObject.port.toString();
+  }
+  if (urlObject.path) {
+    url += urlObject.getPath();
+  }
+  if (urlObject.query && urlObject.query.count()) {
+    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
+    queryString && (url += '?' + queryString);
+  }
+  if (urlObject.hash) {
+    url += '#' + urlObject.hash;
+  }
+
+  return url;
+}
 };

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -111,6 +111,7 @@ module.exports = {
     }
     return result;
   },
+
   /**
  *
  * @param {*} urlObject The request sdk request.url object
@@ -119,33 +120,36 @@ module.exports = {
  * This will be used because the url.toString() method returned the URL with non encoded query string
  * and hence a manual call is made to getQueryString() method with encode option set as true.
  */
-getUrlStringfromUrlObject: function (urlObject) {
-  var url = '';
-  if (urlObject.protocol) {
-    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
-  }
-  if (urlObject.auth && urlObject.auth.user) {
-    url = url + ((urlObject.auth.password) ?
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
       // ==> username:password@
-      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
-  }
-  if (urlObject.host) {
-    url += urlObject.getHost();
-  }
-  if (urlObject.port) {
-    url += ':' + urlObject.port.toString();
-  }
-  if (urlObject.path) {
-    url += urlObject.getPath();
-  }
-  if (urlObject.query && urlObject.query.count()) {
-    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
-    queryString && (url += '?' + queryString);
-  }
-  if (urlObject.hash) {
-    url += '#' + urlObject.hash;
-  }
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
 
-  return url;
-}
+    return url;
+  }
 };

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -252,5 +252,72 @@ describe('curl convert function', function () {
         }
       });
     });
+
+    it('should not encode queryParam unresolved variables and ' +
+    'leave it inside double parenthesis {{xyz}}', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a={{xyz}}',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': '{{xyz}}'
+            }
+          ]
+        }
+      });
+      options = {};
+      convert(request, options, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a={{xyz}}');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=%7B%7Bxyz%7D%7D');
+      });
+    });
+
+    it('should encode queryParams other than unresolved variables', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a=b c',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': 'b c'
+            }
+          ]
+        }
+      });
+      options = {};
+      convert(request, options, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a=b%20c');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=b c');
+      });
+    });
   });
 });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -5,6 +5,7 @@ var expect = require('chai').expect,
   parallel = require('async').parallel,
 
   convert = require('../../index').convert,
+  getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject,
   mainCollection = require('./fixtures/testcollection/collection.json');
 
 /**
@@ -317,6 +318,111 @@ describe('curl convert function', function () {
         expect(snippet).to.be.a('string');
         expect(snippet).to.include('http://postman-echo.com/post?a=b%20c');
         expect(snippet).to.not.include('http://postman-echo.com/post?a=b c');
+      });
+    });
+
+    describe('getUrlStringfromUrlObject function', function () {
+      var rawUrl, urlObject, outputUrlString;
+
+      it('should return empty string for an url object for an empty url or if no url object is passed', function () {
+        rawUrl = '';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.be.empty;
+        outputUrlString = getUrlStringfromUrlObject();
+        expect(outputUrlString).to.be.empty;
+      });
+
+      it('should add protocol if present in the url object', function () {
+        rawUrl = 'https://postman-echo.com';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      it('should add the auth information if present in the url object', function () {
+        rawUrl = 'https://user:password@postman-echo.com';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      it('should not add the auth information if user isn\'t present but' +
+      ' password is present in the url object', function () {
+        rawUrl = 'https://:password@postman-echo.com';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.not.include(':password');
+      });
+
+      it('should add host if present in the url object', function () {
+        rawUrl = 'https://postman-echo.com';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      it('should add port if present in the url object', function () {
+        rawUrl = 'https://postman-echo.com:8080';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      it('should add path if present in the url object', function () {
+        rawUrl = 'https://postman-echo.com/get';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      describe('queryParams', function () {
+
+        it('should not encode unresolved query params', function () {
+          rawUrl = 'https://postman-echo.com/get?key={{value}}';
+          urlObject = new sdk.Url(rawUrl);
+          outputUrlString = getUrlStringfromUrlObject(urlObject);
+          expect(outputUrlString).to.not.include('key=%7B%7Bvalue%7B%7B');
+          expect(outputUrlString).to.equal(rawUrl);
+        });
+
+        it('should encode query params other than unresolved variables', function () {
+          rawUrl = 'https://postman-echo.com/get?key=\'a b c\'';
+          urlObject = new sdk.Url(rawUrl);
+          outputUrlString = getUrlStringfromUrlObject(urlObject);
+          expect(outputUrlString).to.not.include('key=\'a b c\'');
+          expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
+        });
+
+        it('should not encode unresolved query params and ' +
+        'encode every other query param, both present together', function () {
+          rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b c\'';
+          urlObject = new sdk.Url(rawUrl);
+          outputUrlString = getUrlStringfromUrlObject(urlObject);
+          expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
+          expect(outputUrlString).to.not.include('key2=\'a b c\'');
+          expect(outputUrlString).to.equal('https://postman-echo.com/get?key1={{value}}&key2=%27a%20b%20c%27');
+        });
+
+        it('should discard disabled query params', function () {
+          urlObject = new sdk.Url({
+            protocol: 'https',
+            host: 'postman-echo.com',
+            query: [
+              { key: 'foo', value: 'bar' },
+              { key: 'alpha', value: 'beta', disabled: true }
+            ]
+          });
+          outputUrlString = getUrlStringfromUrlObject(urlObject);
+          expect(outputUrlString).to.equal('https://postman-echo.com?foo=bar');
+        });
+      });
+
+      it('should add hash if present in the url object', function () {
+        rawUrl = 'https://postmanm-echo.com/get#hash';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal(rawUrl);
       });
     });
   });

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -12,6 +12,9 @@ var _ = require('./lodash'),
  */
 function getUrlStringfromUrlObject (urlObject) {
   var url = '';
+  if (!urlObject) {
+    return url;
+  }
   if (urlObject.protocol) {
     url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
   }

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -5,7 +5,10 @@ var _ = require('./lodash'),
 /**
  *
  * @param {*} urlObject The request sdk request.url object
- * @returns {String} final url string converted from parsing url object
+ * @returns {String} The final string after parsing all the parameters of the url including 
+ * protocol, auth, host, port, path, query, hash
+ * This will be used because the url.toString() method returned the URL with non encoded query string
+ * and hence a manual call is made to getQueryString() method with encode option set as true.
  */
 function getUrlStringfromUrlObject (urlObject) {
   var url = '';

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -3,8 +3,43 @@ var _ = require('./lodash'),
   sanitize = require('./util').sanitize;
 
 /**
+ *
+ * @param {*} urlObject The request sdk request.url object
+ * @returns {String} final url string converted from parsing url object
+ */
+function getUrlStringfromUrlObject (urlObject) {
+  var url = '';
+  if (urlObject.protocol) {
+    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+  }
+  if (urlObject.auth && urlObject.auth.user) {
+    url = url + ((urlObject.auth.password) ?
+      // ==> username:password@
+      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+  }
+  if (urlObject.host) {
+    url += urlObject.getHost();
+  }
+  if (urlObject.port) {
+    url += ':' + urlObject.port.toString();
+  }
+  if (urlObject.path) {
+    url += urlObject.getPath();
+  }
+  if (urlObject.query && urlObject.query.count()) {
+    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
+    queryString && (url += '?' + queryString);
+  }
+  if (urlObject.hash) {
+    url += '#' + urlObject.hash;
+  }
+
+  return url;
+}
+
+/**
  * parses form data from request body and returns codesnippet in java unirest
- * 
+ *
  * @param {Object} requestbody - JSON object acquired by request.body.JSON()
  * @param {String} indentString - value for indentation
  * @param {Boolean} trimField - whether to trim fields of the request body
@@ -28,9 +63,9 @@ function parseFormData (requestbody, indentString, trimField) {
 }
 
 /**
- * parses body from request object based on mode provided by request body and 
+ * parses body from request object based on mode provided by request body and
  * returns codesnippet in java unirest
- * 
+ *
  * @param {Object} request - postman request object, more information can be found in postman collection sdk
  * @param {String} indentString - value for indentation
  * @param {Boolean} trimField - whether to trim fields of body of the request
@@ -56,7 +91,7 @@ function parseBody (request, indentString, trimField) {
 
 /**
  * parses header from request and returns codesnippet in java unirest
- * 
+ *
  * @param {Object} request - postman request object, more information can be found in postman collection sdk
  * @param {String} indentString - value for indentation
  * @returns {String} - body string parsed from request object
@@ -75,5 +110,6 @@ function parseHeader (request, indentString) {
 
 module.exports = {
   parseBody: parseBody,
-  parseHeader: parseHeader
+  parseHeader: parseHeader,
+  getUrlStringfromUrlObject: getUrlStringfromUrlObject
 };

--- a/codegens/java-unirest/lib/unirest.js
+++ b/codegens/java-unirest/lib/unirest.js
@@ -16,7 +16,7 @@ const SUPPORTED_METHODS = ['GET', 'POST', 'PUT', 'HEAD', 'PATCH', 'DELETE', 'OPT
  */
 function makeSnippet (request, indentString, options) {
   var snippet = '',
-    urlString = encodeURI(request.url.toString());
+    urlString = parseRequest.getUrlStringfromUrlObject(request.url);
 
   if (options.requestTimeout > 0) {
     snippet += `Unirest.setTimeouts(0, ${options.requestTimeout});\n`;

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -298,6 +298,71 @@ describe('java unirest convert function for test collection', function () {
         expect(snippet).to.include('.get');
       });
     });
+
+    it('should not encode queryParam unresolved variables and ' +
+    'leave it inside double parenthesis {{xyz}}', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a={{xyz}}',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': '{{xyz}}'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a={{xyz}}');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=%7B%7Bxyz%7D%7D');
+      });
+    });
+
+    it('should encode queryParams other than unresolved variables', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a=b c',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': 'b c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a=b%20c');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=b c');
+      });
+    });
   });
 
   describe('getOptions function', function () {

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -7,6 +7,7 @@ var expect = require('chai').expect,
 
   convert = require('../../lib/index').convert,
   sanitize = require('../../lib/util').sanitize,
+  getUrlStringfromUrlObject = require('../../lib/parseRequest').getUrlStringfromUrlObject,
   getOptions = require('../../index').getOptions,
   mainCollection = require('./fixtures/testcollection/collection.json');
 
@@ -364,7 +365,110 @@ describe('java unirest convert function for test collection', function () {
       });
     });
   });
+  describe('getUrlStringfromUrlObject function', function () {
+    var rawUrl, urlObject, outputUrlString;
 
+    it('should return empty string for an url object for an empty url or if no url object is passed', function () {
+      rawUrl = '';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.be.empty;
+      outputUrlString = getUrlStringfromUrlObject();
+      expect(outputUrlString).to.be.empty;
+    });
+
+    it('should add protocol if present in the url object', function () {
+      rawUrl = 'https://postman-echo.com';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+
+    it('should add the auth information if present in the url object', function () {
+      rawUrl = 'https://user:password@postman-echo.com';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+
+    it('should not add the auth information if user isn\'t present but' +
+    ' password is present in the url object', function () {
+      rawUrl = 'https://:password@postman-echo.com';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.not.include(':password');
+    });
+
+    it('should add host if present in the url object', function () {
+      rawUrl = 'https://postman-echo.com';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+
+    it('should add port if present in the url object', function () {
+      rawUrl = 'https://postman-echo.com:8080';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+
+    it('should add path if present in the url object', function () {
+      rawUrl = 'https://postman-echo.com/get';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+
+    describe('queryParams', function () {
+
+      it('should not encode unresolved query params', function () {
+        rawUrl = 'https://postman-echo.com/get?key={{value}}';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.not.include('key=%7B%7Bvalue%7B%7B');
+        expect(outputUrlString).to.equal(rawUrl);
+      });
+
+      it('should encode query params other than unresolved variables', function () {
+        rawUrl = 'https://postman-echo.com/get?key=\'a b c\'';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.not.include('key=\'a b c\'');
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
+      });
+
+      it('should not encode unresolved query params and ' +
+      'encode every other query param, both present together', function () {
+        rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b c\'';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
+        expect(outputUrlString).to.not.include('key2=\'a b c\'');
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?key1={{value}}&key2=%27a%20b%20c%27');
+      });
+
+      it('should discard disabled query params', function () {
+        urlObject = new sdk.Url({
+          protocol: 'https',
+          host: 'postman-echo.com',
+          query: [
+            { key: 'foo', value: 'bar' },
+            { key: 'alpha', value: 'beta', disabled: true }
+          ]
+        });
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal('https://postman-echo.com?foo=bar');
+      });
+    });
+
+    it('should add hash if present in the url object', function () {
+      rawUrl = 'https://postmanm-echo.com/get#hash';
+      urlObject = new sdk.Url(rawUrl);
+      outputUrlString = getUrlStringfromUrlObject(urlObject);
+      expect(outputUrlString).to.equal(rawUrl);
+    });
+  });
   describe('getOptions function', function () {
 
     it('should return an array of specific options', function () {

--- a/codegens/ruby/test/unit/converter.test.js
+++ b/codegens/ruby/test/unit/converter.test.js
@@ -135,7 +135,6 @@ describe('Ruby converter', function () {
         };
       convert(request, {indentType: 'Space',
         indentCount: 4,
-        requestTimeout: 1000,
         trimRequestBody: false,
         addCacheHeader: false,
         followRedirect: true}, function (err, snippet) {

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -3,6 +3,41 @@ var _ = require('./lodash'),
   sanitizeOptions = require('./util').sanitizeOptions,
   self;
 
+  /**
+ *
+ * @param {*} urlObject The request sdk request.url object
+ * @returns {String} final url string converted from parsing url object
+ */
+function getUrlStringfromUrlObject (urlObject) {
+  var url = '';
+  if (urlObject.protocol) {
+    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+  }
+  if (urlObject.auth && urlObject.auth.user) {
+    url = url + ((urlObject.auth.password) ?
+      // ==> username:password@
+      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+  }
+  if (urlObject.host) {
+    url += urlObject.getHost();
+  }
+  if (urlObject.port) {
+    url += ':' + urlObject.port.toString();
+  }
+  if (urlObject.path) {
+    url += urlObject.getPath();
+  }
+  if (urlObject.query && urlObject.query.count()) {
+    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
+    queryString && (url += '?' + queryString);
+  }
+  if (urlObject.hash) {
+    url += '#' + urlObject.hash;
+  }
+
+  return url;
+}
+
 /**
  * Parses Raw data from request to fetch syntax
  *
@@ -228,7 +263,7 @@ self = module.exports = {
     timeout = options.requestTimeout;
     // followRedirect = options.followRedirect;
     trim = options.trimRequestBody;
-    finalUrl = encodeURI(request.url.toString());
+    finalUrl = getUrlStringfromUrlObject(request.url);
 
     bodySnippet = parseBody(requestBody, trim, indent);
 

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -1,45 +1,8 @@
 var _ = require('./lodash'),
   sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   self;
-
-/**
- *
- * @param {*} urlObject The request sdk request.url object
- * @returns {String} The final string after parsing all the parameters of the url including 
- * protocol, auth, host, port, path, query, hash
- * This will be used because the url.toString() method returned the URL with non encoded query string
- * and hence a manual call is made to getQueryString() method with encode option set as true.
- */
-function getUrlStringfromUrlObject (urlObject) {
-  var url = '';
-  if (urlObject.protocol) {
-    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
-  }
-  if (urlObject.auth && urlObject.auth.user) {
-    url = url + ((urlObject.auth.password) ?
-      // ==> username:password@
-      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
-  }
-  if (urlObject.host) {
-    url += urlObject.getHost();
-  }
-  if (urlObject.port) {
-    url += ':' + urlObject.port.toString();
-  }
-  if (urlObject.path) {
-    url += urlObject.getPath();
-  }
-  if (urlObject.query && urlObject.query.count()) {
-    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
-    queryString && (url += '?' + queryString);
-  }
-  if (urlObject.hash) {
-    url += '#' + urlObject.hash;
-  }
-
-  return url;
-}
 
 /**
  * Parses Raw data from request to fetch syntax

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -3,10 +3,13 @@ var _ = require('./lodash'),
   sanitizeOptions = require('./util').sanitizeOptions,
   self;
 
-  /**
+/**
  *
  * @param {*} urlObject The request sdk request.url object
- * @returns {String} final url string converted from parsing url object
+ * @returns {String} The final string after parsing all the parameters of the url including 
+ * protocol, auth, host, port, path, query, hash
+ * This will be used because the url.toString() method returned the URL with non encoded query string
+ * and hence a manual call is made to getQueryString() method with encode option set as true.
  */
 function getUrlStringfromUrlObject (urlObject) {
   var url = '';

--- a/codegens/swift/lib/util.js
+++ b/codegens/swift/lib/util.js
@@ -101,7 +101,46 @@ function sanitizeOptions (options, optionsArray) {
   return result;
 }
 
+/**
+ *
+ * @param {*} urlObject The request sdk request.url object
+ * @returns {String} The final string after parsing all the parameters of the url including 
+ * protocol, auth, host, port, path, query, hash
+ * This will be used because the url.toString() method returned the URL with non encoded query string
+ * and hence a manual call is made to getQueryString() method with encode option set as true.
+ */
+function getUrlStringfromUrlObject (urlObject) {
+  var url = '';
+  if (urlObject.protocol) {
+    url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+  }
+  if (urlObject.auth && urlObject.auth.user) {
+    url = url + ((urlObject.auth.password) ?
+      // ==> username:password@
+      urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+  }
+  if (urlObject.host) {
+    url += urlObject.getHost();
+  }
+  if (urlObject.port) {
+    url += ':' + urlObject.port.toString();
+  }
+  if (urlObject.path) {
+    url += urlObject.getPath();
+  }
+  if (urlObject.query && urlObject.query.count()) {
+    let queryString = urlObject.getQueryString({ ignoreDisabled: true, encode: true });
+    queryString && (url += '?' + queryString);
+  }
+  if (urlObject.hash) {
+    url += '#' + urlObject.hash;
+  }
+
+  return url;
+}
+
 module.exports = {
   sanitize: sanitize,
-  sanitizeOptions: sanitizeOptions
+  sanitizeOptions: sanitizeOptions,
+  getUrlStringfromUrlObject: getUrlStringfromUrlObject
 };

--- a/codegens/swift/lib/util.js
+++ b/codegens/swift/lib/util.js
@@ -111,6 +111,9 @@ function sanitizeOptions (options, optionsArray) {
  */
 function getUrlStringfromUrlObject (urlObject) {
   var url = '';
+  if (!urlObject) {
+    return url;
+  }
   if (urlObject.protocol) {
     url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
   }

--- a/codegens/swift/test/unit/convert.test.js
+++ b/codegens/swift/test/unit/convert.test.js
@@ -189,6 +189,71 @@ describe('Swift Converter', function () {
 
       });
     });
+
+    it('should not encode queryParam unresolved variables and ' +
+    'leave it inside double parenthesis {{xyz}}', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a={{xyz}}',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': '{{xyz}}'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a={{xyz}}');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=%7B%7Bxyz%7D%7D');
+      });
+    });
+
+    it('should encode queryParams other than unresolved variables', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'http://postman-echo.com/post?a=b c',
+          'protocol': 'http',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ],
+          'query': [
+            {
+              'key': 'a',
+              'value': 'b c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('http://postman-echo.com/post?a=b%20c');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a=b c');
+      });
+    });
   });
 
   describe('getOptions function', function () {


### PR DESCRIPTION
Some of the codegens doesn't encode url on its own and fails to run if not encoded.
For such codegens, we have decided to encode everything in the url other than the unresolved variables
Languages affected: 
- curl
- swift
- java-unirest