### PR TITLE
Removed changing of { to [ everywhere inside formdata JSON body to convert it to swift dictionary

### DIFF
--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -51,8 +51,26 @@ function parseURLEncodedBody (body, mode, trim) {
  * @returns {String} request body in the desired format
  */
 function parseFormData (body, mode, trim, indent) {
-  var parameters = sanitize(JSON.stringify(body, null, 4), mode, trim),
-    bodySnippet = `let parameters = ${parameters} as [[String : Any]]\n\n`;
+  var parameters = [],
+    parameter,
+    bodySnippet;
+  _.forEach(body, (data) => {
+    if (!(data.disabled)) {
+      parameter = '';
+      parameter += `${indent}[\n${indent.repeat(2)}"key": "${sanitize(data.key, mode, trim)}",\n`;
+      if (data.type === 'file') {
+        parameter += `${indent.repeat(2)}"src": "${sanitize(data.src, mode, trim)}",\n`;
+        parameter += `${indent.repeat(2)}"type": "file"\n${indent}]`;
+      }
+      else {
+        parameter += `${indent.repeat(2)}"value": "${sanitize(data.value, mode, trim)}",\n`;
+        parameter += `${indent.repeat(2)}"type": "text"\n${indent}]`;
+      }
+      parameters.push(parameter);
+    }
+  });
+  parameters = '[\n' + _.join(parameters, ',\n') + ']';
+  bodySnippet = `let parameters = ${parameters} as [[String : Any]]\n\n`;
   bodySnippet += 'let boundary = "Boundary-\\(UUID().uuidString)"\n';
   bodySnippet += 'var body = ""\nvar error: Error? = nil\n';
   bodySnippet += 'for param in parameters {\n';

--- a/codegens/swift/lib/util.js
+++ b/codegens/swift/lib/util.js
@@ -19,7 +19,7 @@ function sanitize (inputString, escapeCharFor, inputTrim) {
       case 'urlencoded':
         return escape(inputString);
       case 'formdata':
-        return inputString.replace(/{/g, '[').replace(/}/g, ']');
+        return inputString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         /* istanbul ignore next */
       case 'file':
         return inputString.replace(/{/g, '[').replace(/}/g, ']');


### PR DESCRIPTION
Details: 
For sending the form data parameters, we used to form a swift dictionary from the request body JSON that we get from request object.
the code used was: `sanitize(JSON.stringify(body, null, 4), mode, trim)`
and sanitize for form data was: `inputString.replace(/{/g, '[').replace(/}/g, ']')`
Sanitize had this code because the swift dictionary used `[` and `]`.

Two problems:
1. Hardcoding paramater as 4 in `JSON.stringify()` doesn't take into account the indentation option we provide.
2. If parameter key or value contains a `[` or `]` , it was being replaced by `{` and `}` respectively.
Fixed the issue by manually parsing the request body to form the swift dictionary accordingly