### PR TITLE
Replaced usage of double quotes with single quotes in entire curl snippet

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -37,15 +37,15 @@ self = module.exports = {
     }
     url = getUrlStringfromUrlObject(request.url);
     if (request.method === 'HEAD') {
-      snippet += ` ${form('-I', format)} "${url}"`;
+      snippet += ` ${form('-I', format)} '${url}'`;
     }
     else {
-      snippet += ` ${form('-X', format)} ${request.method} "${url}"`;
+      snippet += ` ${form('-X', format)} ${request.method} '${url}'`;
     }
 
     headersData = request.getHeaders({ enabled: true });
     _.forEach(headersData, function (value, key) {
-      snippet += indent + `${form('-H', format)} "${sanitize(key, trim)}: ${sanitize(value, trim)}"`;
+      snippet += indent + `${form('-H', format)} '${sanitize(key, trim)}: ${sanitize(value, trim)}'`;
     });
 
     if (request.body) {
@@ -60,31 +60,31 @@ self = module.exports = {
                 text.push(`${escape(data.key)}=${escape(data.value)}`);
               }
             });
-            snippet += indent + `${form('-d', format)} "${text.join('&')}"`;
+            snippet += indent + `${form('-d', format)} '${text.join('&')}'`;
             break;
           case 'raw':
-            snippet += indent + `${form('-d', format)} "${sanitize(body.raw.toString(), trim)}"`;
+            snippet += indent + `${form('-d', format)} '${sanitize(body.raw.toString(), trim)}'`;
             break;
           case 'formdata':
             _.forEach(body.formdata, function (data) {
               if (!(data.disabled)) {
                 if (data.type === 'file') {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` "${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}"`;
+                  snippet += ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` "${sanitize(data.key, trim)}=${sanitize(data.value, trim)}"`;
+                  snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
                 }
               }
             });
             break;
           case 'file':
             snippet += indent + `${form('--data-binary', format)}`;
-            snippet += ` "${sanitize(body.key, trim)}=@${sanitize(body.value, trim)}"`;
+            snippet += ` '${sanitize(body.key, trim)}=@${sanitize(body.value, trim)}'`;
             break;
           default:
-            snippet += `${form('-d', format)} ""`;
+            snippet += `${form('-d', format)} ''`;
         }
       }
     }

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -11,7 +11,8 @@ module.exports = {
     if (typeof inputString !== 'string') {
       return '';
     }
-    inputString = inputString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    // for curl escaping of single quotes inside single quotes involves changing of ' to '\''
+    inputString = inputString.replace(/'/g, '\'\\\'\'');
     return trim ? inputString.trim() : inputString;
   },
   form: function (option, format) {
@@ -115,7 +116,7 @@ module.exports = {
   /**
  *
  * @param {*} urlObject The request sdk request.url object
- * @returns {String} The final string after parsing all the parameters of the url including 
+ * @returns {String} The final string after parsing all the parameters of the url including
  * protocol, auth, host, port, path, query, hash
  * This will be used because the url.toString() method returned the URL with non encoded query string
  * and hence a manual call is made to getQueryString() method with encode option set as true.

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -198,7 +198,7 @@ describe('curl convert function', function () {
         if (error) {
           expect.fail(null, null, error);
         }
-        expect(snippet).to.include('-H "foo: \\\"bar\\\""'); // eslint-disable-line no-useless-escape
+        expect(snippet).to.include('-H \'foo: "bar"\'');
       });
     });
 
@@ -223,7 +223,7 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('GET "https://google.com"');
+        expect(snippet).to.include('GET \'https://google.com\'');
       });
     });
 


### PR DESCRIPTION
This fixes #72 
This will improve the readability of curl command as previously entire JSON body used to have double quotes and we used to escape each and every double quote as --data used double quotes to define data.