### PR TITLE
General bugfixes in 0.0.11

### DIFF
--- a/codegens/ocaml-cohttp/lib/ocaml.js
+++ b/codegens/ocaml-cohttp/lib/ocaml.js
@@ -154,20 +154,12 @@ function parseHeaders (bodyMode, headers, indent) {
       headerSnippet += `"${sanitize(value, 'header')}"\n`;
     });
   }
-  if (bodyMode === 'formdata' || bodyMode === 'file') {
+  if (bodyMode === 'formdata') {
     if (headerSnippet === '') {
       headerSnippet += `${indent}let headers = Header.init ()\n`;
     }
-    if (bodyMode === 'formdata') {
-      headerSnippet += `${indent.repeat(2)}|> fun h -> Header.add h "content-type" "multipart/form-data;`;
-      headerSnippet += ' boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW"\n';
-    }
-    // Ignoring next part as this header is specific to body type file. and there is no test for it.
-    /* istanbul ignore next */
-    else {
-      headerSnippet += `${indent.repeat(2)}|> fun h -> Header.add h "content-type"`;
-      headerSnippet += ' "{Insert_File_Content_Type}"\n';
-    }
+    headerSnippet += `${indent.repeat(2)}|> fun h -> Header.add h "content-type" "multipart/form-data;`;
+    headerSnippet += ' boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW"\n';
   }
   return headerSnippet;
 }

--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -20,7 +20,7 @@ function getheaders (request, indentation) {
       return `${indentation}'${sanitize(key, 'header')}': ` +
             `'${sanitize(headerObject[key], 'header')}'`;
     });
-    return `headers ={\n${headerMap.join(',\n')}}\n`;
+    return `headers = {\n${headerMap.join(',\n')}\n}\n`;
   }
   return 'headers= {}\n';
 }


### PR DESCRIPTION
- Removed addition of content-type header twice for binary file upload in ocaml
- indentation fixes in python-requests headers