### PR TITLE
Added support for using special characters in raw body mode in shell-httpie

### DIFF
--- a/codegens/shell-httpie/lib/util/helpers.js
+++ b/codegens/shell-httpie/lib/util/helpers.js
@@ -190,7 +190,7 @@ module.exports = {
           parsedBody = '';
         }
         else {
-          parsedBody = requestBody ? `${Sanitize.quote(requestBody)}` : '';
+          parsedBody = requestBody ? `${Sanitize.quote(requestBody, RAW)}` : '';
         }
         break;
       case 'file':

--- a/codegens/shell-httpie/lib/util/sanitize.js
+++ b/codegens/shell-httpie/lib/util/sanitize.js
@@ -1,9 +1,14 @@
 module.exports = {
-  quote: function (value) {
+  quote: function (value, mode) {
     if (typeof value !== 'string' || value === '') {
       return '';
     }
-    return '\'' + value.replace(/\\/g, '\\\\').replace(/'/g, '\'\\\'\'') + '\'';
+    switch (mode) {
+      case 'raw':
+        return '\'' + value.replace(/\\/g, '\\\\').replace(/'/g, '\'\\\'\'').replace(/%/, '%%') + '\'';
+      default:
+        return '\'' + value.replace(/\\/g, '\\\\').replace(/'/g, '\'\\\'\'') + '\'';
+    }
   },
 
   /**


### PR DESCRIPTION
multipart/form-data
- Using  --form, -f option ensures that data fields are serialized as, and Content-Type is set to, application/x-www-form-urlencoded; charset=utf-8. 
- If one or more file fields is present, the serialization and content type is multipart/form-data
- docs: https://httpie.org/doc#regular-forms
Thus it is not possible to send non-file fields in httpie using multipart/form-data.

special character in raw text
- It used to fail because we use printf 'raw data' and then pipe it to httpie, which is the only way to post raw data using it. But % is interpreted as special character when used with printf, hence added the logic to escape %, i.e. use `%%` instead of `%`

urlencoded
- It supports x-www-form-urlencoded data