### PR TITLE
Added long format options for different data sending methods in curl

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -37,15 +37,15 @@ self = module.exports = {
     }
     url = getUrlStringfromUrlObject(request.url);
     if (request.method === 'HEAD') {
-      snippet += ` ${form('-I', format)} "${url}"`;
+      snippet += ` ${form('-I', format)} '${url}'`;
     }
     else {
-      snippet += ` ${form('-X', format)} ${request.method} "${url}"`;
+      snippet += ` ${form('-X', format)} ${request.method} '${url}'`;
     }
 
     headersData = request.getHeaders({ enabled: true });
     _.forEach(headersData, function (value, key) {
-      snippet += indent + `${form('-H', format)} "${sanitize(key, trim)}: ${sanitize(value, trim)}"`;
+      snippet += indent + `${form('-H', format)} '${sanitize(key, trim)}: ${sanitize(value, trim)}'`;
     });
 
     if (request.body) {
@@ -60,31 +60,31 @@ self = module.exports = {
                 text.push(`${escape(data.key)}=${escape(data.value)}`);
               }
             });
-            snippet += indent + `${form('-d', format)} "${text.join('&')}"`;
+            snippet += indent + `${form('-d', format)} '${text.join('&')}'`;
             break;
           case 'raw':
-            snippet += indent + `${form('-d', format)} "${sanitize(body.raw.toString(), trim)}"`;
+            snippet += indent + `${form('-d', format)} '${sanitize(body.raw.toString(), trim)}'`;
             break;
           case 'formdata':
             _.forEach(body.formdata, function (data) {
               if (!(data.disabled)) {
                 if (data.type === 'file') {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` "${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}"`;
+                  snippet += ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` "${sanitize(data.key, trim)}=${sanitize(data.value, trim)}"`;
+                  snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
                 }
               }
             });
             break;
           case 'file':
             snippet += indent + `${form('--data-binary', format)}`;
-            snippet += ` "${sanitize(body.key, trim)}=@${sanitize(body.value, trim)}"`;
+            snippet += ` '${sanitize(body.key, trim)}=@${sanitize(body.value, trim)}'`;
             break;
           default:
-            snippet += `${form('-d', format)} ""`;
+            snippet += `${form('-d', format)} ''`;
         }
       }
     }

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -13,7 +13,7 @@ self = module.exports = {
     }
     options = sanitizeOptions(options, self.getOptions());
 
-    var indent, trim, headersData, body, text, redirect, timeout, multiLine,
+    var indent, trim, headersData, body, redirect, timeout, multiLine,
       format, snippet, silent, url;
 
     redirect = options.followRedirect;
@@ -62,16 +62,15 @@ self = module.exports = {
       if (!_.isEmpty(body)) {
         switch (body.mode) {
           case 'urlencoded':
-            text = [];
             _.forEach(body.urlencoded, function (data) {
               if (!data.disabled) {
-                text.push(`${escape(data.key)}=${escape(data.value)}`);
+                snippet += indent + `${form('--data-urlencode', format)}`;
+                snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
               }
             });
-            snippet += indent + `${form('-d', format)} '${text.join('&')}'`;
             break;
           case 'raw':
-            snippet += indent + `${form('-d', format)} '${sanitize(body.raw.toString(), trim)}'`;
+            snippet += indent + `${form('--data-raw', format)} '${sanitize(body.raw.toString(), trim)}'`;
             break;
           case 'formdata':
             _.forEach(body.formdata, function (data) {
@@ -89,7 +88,7 @@ self = module.exports = {
             break;
           case 'file':
             snippet += indent + `${form('--data-binary', format)}`;
-            snippet += ` "@${sanitize(body[body.mode].src, trim)}"`;
+            snippet += ` '@${sanitize(body[body.mode].src, trim)}'`;
             break;
           default:
             snippet += `${form('-d', format)} ''`;

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -36,6 +36,10 @@ module.exports = {
           return '--form';
         case '--data-binary':
           return '--data-binary';
+        case '--data-urlencode':
+          return '--data-urlencode';
+        case '--data-raw':
+          return '--data-raw';
         default:
           return '';
       }

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -11,7 +11,8 @@ module.exports = {
     if (typeof inputString !== 'string') {
       return '';
     }
-    inputString = inputString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    // for curl escaping of single quotes inside single quotes involves changing of ' to '\''
+    inputString = inputString.replace(/'/g, '\'\\\'\'');
     return trim ? inputString.trim() : inputString;
   },
   form: function (option, format) {
@@ -115,7 +116,7 @@ module.exports = {
   /**
  *
  * @param {*} urlObject The request sdk request.url object
- * @returns {String} The final string after parsing all the parameters of the url including 
+ * @returns {String} The final string after parsing all the parameters of the url including
  * protocol, auth, host, port, path, query, hash
  * This will be used because the url.toString() method returned the URL with non encoded query string
  * and hence a manual call is made to getQueryString() method with encode option set as true.

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -12,7 +12,7 @@ module.exports = {
       return '';
     }
     // for curl escaping of single quotes inside single quotes involves changing of ' to '\''
-    inputString = inputString.replace(/'/g, '\'\\\'\'');
+    inputString = inputString.replace(/'/g, "'\\''"); // eslint-disable-line quotes
     return trim ? inputString.trim() : inputString;
   },
   form: function (option, format) {

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -198,7 +198,7 @@ describe('curl convert function', function () {
         if (error) {
           expect.fail(null, null, error);
         }
-        expect(snippet).to.include('-H \'foo: "bar"\'');
+        expect(snippet).to.include("-H 'foo: \"bar\"'"); // eslint-disable-line quotes
       });
     });
 
@@ -223,7 +223,7 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('GET \'https://google.com\'');
+        expect(snippet).to.include("GET 'https://google.com'"); // eslint-disable-line quotes
       });
     });
 

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -198,7 +198,7 @@ describe('curl convert function', function () {
         if (error) {
           expect.fail(null, null, error);
         }
-        expect(snippet).to.include('-H "foo: \\\"bar\\\""'); // eslint-disable-line no-useless-escape
+        expect(snippet).to.include('-H \'foo: "bar"\'');
       });
     });
 
@@ -223,7 +223,7 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('GET "https://google.com"');
+        expect(snippet).to.include('GET \'https://google.com\'');
       });
     });
 


### PR DESCRIPTION
we were using --data or -d (short form) to send raw data as well as urlencoded data. Problems with using this:

1. @ has a special interpretation when used with --data, i.e. it expects a file path after it. Whereas if the user has selected raw body within postman, he clearly doesn't want this @ to be interpreted as a file upload but merely a character. curl specifies to use --data-raw if we don't want to have special interpretation of @ character.
2. Using --data for urlencoded has other cons. We were manually encoding characters and then sending this data using --data. Whereas curl specifies using --data-urlencode format for sending url encoded values, and it does encoding on its own.