### PR TITLE
Java-unirest formdata fix and tests

### DIFF
--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -85,7 +85,11 @@ function parseBody (request, indentString, trimField) {
       case 'raw':
         return indentString + `.body(${JSON.stringify(request.body.toString())})\n`;
       case 'formdata':
-        return parseFormData(request.body.toJSON(), indentString, trimField);
+        var formDataContent = parseFormData(request.body.toJSON(), indentString, trimField);
+        if (!formDataContent.includes('.field("file", new File')) {
+          formDataContent = indentString + '.multiPartContent()' + formDataContent;
+        }
+        return formDataContent;
       case 'file':
         return indentString + '.body("<file contents here>")\n';
       default:

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -246,6 +246,82 @@ describe('java unirest convert function for test collection', function () {
         expect(snippet).to.include('.header("key_containing_whitespaces", "  value_containing_whitespaces  ")');
       });
     });
+
+    it('should add the force multipart body method when ' +
+      'there are no files but contains text field params in multipart/form-data', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'key1',
+              'value': 'value1',
+              'type': 'text'
+            },
+            {
+              'key': 'key2',
+              'value': 'value2',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'https://postman-echo/',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('.multiPartContent()');
+        expect(snippet).to.include('.field("key1", "value1")');
+        expect(snippet).to.include('.field("key2", "value2")');
+      });
+    });
+
+    it('should not add the force multipart body method when ' +
+      'there are file fields in multipart/form-data', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'key1',
+              'value': 'value1',
+              'type': 'file'
+            },
+            {
+              'key': 'key2',
+              'value': 'value2',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'https://postman-echo/',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.not.include('.multiPartContent()');
+      });
+    });
   });
   describe('getUrlStringfromUrlObject function', function () {
     var rawUrl, urlObject, outputUrlString;


### PR DESCRIPTION
Java-unirest by default sends the form data parameters as x-www-form-urlencoded if there are no file fields present. After java-unirest 2.1, they have added a method name .multiPartContent() that forces the fields to be sent as multipart/form-data even if there are not file fields present.

Added the above fix and added the corresponding unit tests.