### PR TITLE
Update index.js

### DIFF
--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -224,7 +224,6 @@ function convert (request, options, callback) {
   if (!options.followRedirect) {
     codeSnippet += ' -MaximumRedirection 0';
   }
-  codeSnippet += '\n$response | ConvertTo-Json';
   callback(null, codeSnippet);
 }
 

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -224,6 +224,7 @@ function convert (request, options, callback) {
   if (!options.followRedirect) {
     codeSnippet += ' -MaximumRedirection 0';
   }
+  codeSnippet += '\n$response';
   callback(null, codeSnippet);
 }
 


### PR DESCRIPTION
`Invoke-RestMethod` converts the response from JSON to a PowerShell native object.

From https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod
> If the request returns JSON strings, `Invoke-RestMethod` returns a PSObject that represents the strings

why are we calling `ConvertTo-Json` to convert it back to JSON? it's more useful to leave it as is. if you want just the raw text, use `Invoke-WebRequest` instead