### PR TITLE
Fixed failing code generation in http for requests without body

### DIFF
--- a/codegens/http/lib/util.js
+++ b/codegens/http/lib/util.js
@@ -169,7 +169,7 @@ function getHeaders (request) {
 
   if (contentTypeIndex >= 0) {
     if (request.headers.members[contentTypeIndex].value === 'multipart/form-data' ||
-      (request.bidy && request.body.mode === 'formdata')) {
+      (request.body && request.body.mode === 'formdata')) {
       request.headers.members[contentTypeIndex].value = formDataHeader;
     }
   }

--- a/codegens/http/lib/util.js
+++ b/codegens/http/lib/util.js
@@ -168,7 +168,8 @@ function getHeaders (request) {
     headers = '';
 
   if (contentTypeIndex >= 0) {
-    if (request.headers.members[contentTypeIndex].value === 'multipart/form-data' || request.body.mode === 'formdata') {
+    if (request.headers.members[contentTypeIndex].value === 'multipart/form-data' ||
+      (request.bidy && request.body.mode === 'formdata')) {
       request.headers.members[contentTypeIndex].value = formDataHeader;
     }
   }
@@ -177,7 +178,7 @@ function getHeaders (request) {
     header.key = header.key.trim();
   });
   headers = convertPropertyListToString(request.headers, '\n', false);
-  if (request.body.mode === 'formdata' && contentTypeIndex < 0) {
+  if (request.body && request.body.mode === 'formdata' && contentTypeIndex < 0) {
     headers += `Content-Type: ${formDataHeader}`;
   }
   return headers;

--- a/codegens/http/test/unit/converter.test.js
+++ b/codegens/http/test/unit/converter.test.js
@@ -55,7 +55,12 @@ describe('Converter test', function () {
   it('should generate snippets(not error out) for requests with no body', function () {
     var request = new Request({
       'method': 'GET',
-      'header': [],
+      'header': [
+        {
+          'key': 'Content-Type',
+          'value': 'text/plain'
+        }
+      ],
       'url': {
         'raw': 'https://postman-echo.com/get',
         'protocol': 'https',

--- a/codegens/http/test/unit/converter.test.js
+++ b/codegens/http/test/unit/converter.test.js
@@ -52,6 +52,29 @@ describe('Converter test', function () {
       expect(snippet).to.include('key_containing_whitespaces:   value_containing_whitespaces  ');
     });
   });
+  it.only('should generate snippets(not error out) for requests with no body', function () {
+    var request = new Request({
+      'method': 'GET',
+      'header': [],
+      'url': {
+        'raw': 'https://postman-echo.com/get',
+        'protocol': 'https',
+        'host': [
+          'postman-echo',
+          'com'
+        ],
+        'path': [
+          'get'
+        ]
+      }
+    });
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+    });
+  });
 });
 
 describe('Converter test using options.trimRequestBody', function () {

--- a/codegens/http/test/unit/converter.test.js
+++ b/codegens/http/test/unit/converter.test.js
@@ -52,7 +52,7 @@ describe('Converter test', function () {
       expect(snippet).to.include('key_containing_whitespaces:   value_containing_whitespaces  ');
     });
   });
-  it.only('should generate snippets(not error out) for requests with no body', function () {
+  it('should generate snippets(not error out) for requests with no body', function () {
     var request = new Request({
       'method': 'GET',
       'header': [],


### PR DESCRIPTION
- Create a GET request with no body. Save it to a collection and click view in web. It fails to generate snippets for HTTP.
- It fails for all the requests where no body is present.
- The following function tries to access request.body.mode without having a check for the body field to be present:
```function getHeaders (request) {
  let contentTypeIndex = _.findIndex(request.headers.members, { key: 'Content-Type' }),
    formDataHeader = `multipart/form-data; boundary=${FORM_DATA_BOUNDARY}`,
    headers = '';
 
  if (contentTypeIndex >= 0) {
    if (request.headers.members[contentTypeIndex].value === 'multipart/form-data' || request.body.mode === 'formdata') {
      request.headers.members[contentTypeIndex].value = formDataHeader;
    }
  }
 
  _.forEach(request.headers.members, (header) => {
    header.key = header.key.trim();
  });
  headers = convertPropertyListToString(request.headers, '\n', false);
  if (request.body.mode === 'formdata' && contentTypeIndex < 0) {
    headers += `Content-Type: ${formDataHeader}`;
  }
  return headers;
}
```
- Added checks for request.body in the above function and corresponding tests.




