### PR TITLE
Sanitisation of single/double quotes in url

### DIFF
--- a/codegens/js-fetch/lib/index.js
+++ b/codegens/js-fetch/lib/index.js
@@ -305,7 +305,7 @@ function convert (request, options, callback) {
 
   codeSnippet += optionsSnippet + '\n';
 
-  fetchSnippet = `fetch('${request.url.toString()}', requestOptions)\n${indent}`;
+  fetchSnippet = `fetch("${sanitize(request.url.toString())}", requestOptions)\n${indent}`;
   fetchSnippet += `.then(response => response.text())\n${indent}`;
   fetchSnippet += `.then(result => console.log(result))\n${indent}`;
   fetchSnippet += '.catch(error => console.log(\'error\', error));';

--- a/codegens/js-fetch/test/unit/convert.test.js
+++ b/codegens/js-fetch/test/unit/convert.test.js
@@ -247,7 +247,7 @@ describe('js-fetch convert function for test collection', function () {
           'query': [
             {
               'key': 'query1',
-              'value': 'b\'b'
+              'value': "b'b" // eslint-disable-line quotes
             },
             {
               'key': 'query2',

--- a/codegens/js-fetch/test/unit/convert.test.js
+++ b/codegens/js-fetch/test/unit/convert.test.js
@@ -229,6 +229,41 @@ describe('js-fetch convert function for test collection', function () {
         expect(snippet).to.include('formdata.append("invalid src", fileInput.files[0], "file")');
       });
     });
+
+    it('should generate valid snippet for single/double quotes in url', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'https://postman-echo.com/get?query1=b\'b&query2=c"c',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ],
+          'query': [
+            {
+              'key': 'query1',
+              'value': 'b\'b'
+            },
+            {
+              'key': 'query2',
+              'value': 'c"c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('fetch("https://postman-echo.com/get?query1=b\'b&query2=c\\"c"');
+      });
+    });
   });
 
   describe('getOptions function', function () {

--- a/codegens/nodejs-native/lib/parseRequest.js
+++ b/codegens/nodejs-native/lib/parseRequest.js
@@ -205,7 +205,7 @@ function parsePath (request, indentString) {
     querySnippet = '';
 
   if (pathArray && pathArray.length) {
-    pathSnippet += _.reduce(pathArray, function (accumalator, key) {
+    pathSnippet += sanitize(_.reduce(pathArray, function (accumalator, key) {
       if (key.length) {
         accumalator.push(`${sanitize(key)}`);
       }
@@ -213,7 +213,7 @@ function parsePath (request, indentString) {
         accumalator.push('');
       }
       return accumalator;
-    }, []).join('/');
+    }, []).join('/'));
   }
 
   if (queryArray && queryArray.length) {
@@ -230,7 +230,7 @@ function parsePath (request, indentString) {
       }, []).join('&');
     }
   }
-  pathSnippet += querySnippet + '\'';
+  pathSnippet += sanitize(querySnippet) + '\'';
   return pathSnippet;
 }
 

--- a/codegens/nodejs-native/lib/parseRequest.js
+++ b/codegens/nodejs-native/lib/parseRequest.js
@@ -224,13 +224,13 @@ function parsePath (request, indentString) {
     if (queryExists) {
       querySnippet += '?' + _.reduce(queryArray, function (accumalator, queryElement) {
         if (!queryElement.disabled || _.get(queryElement, 'disabled') === false) {
-          accumalator.push(`${queryElement.key}=${encodeURIComponent(sanitize(queryElement.value))}`);
+          accumalator.push(`${queryElement.key}=${sanitize(encodeURIComponent(queryElement.value))}`);
         }
         return accumalator;
       }, []).join('&');
     }
   }
-  pathSnippet += sanitize(querySnippet) + '\'';
+  pathSnippet += querySnippet + '\'';
   return pathSnippet;
 }
 

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -192,7 +192,7 @@ describe('nodejs-native convert function', function () {
         'query': [
           {
             'key': 'query1',
-            'value': 'b\'b'
+            'value': "b'b" // eslint-disable-line quotes
           },
           {
             'key': 'query2',

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -175,4 +175,39 @@ describe('nodejs-native convert function', function () {
       expect(snippet).to.include('name=\\"invalid src\\"; filename=\\"file\\"');
     });
   });
+  it('should generate valid snippet for single/double quotes in url', function () {
+    var request = new sdk.Request({
+      'method': 'GET',
+      'header': [],
+      'url': {
+        'raw': 'https://postman-echo.com/get?query1=b\'b&query2=c"c',
+        'protocol': 'https',
+        'host': [
+          'postman-echo',
+          'com'
+        ],
+        'path': [
+          'get'
+        ],
+        'query': [
+          {
+            'key': 'query1',
+            'value': 'b\'b'
+          },
+          {
+            'key': 'query2',
+            'value': 'c"c'
+          }
+        ]
+      }
+    });
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      // eslint-disable-next-line quotes
+      expect(snippet).to.include("'path': '/get?query1=b\\'b&query2=c%22c'");
+    });
+  });
 });

--- a/codegens/nodejs-unirest/lib/unirest.js
+++ b/codegens/nodejs-unirest/lib/unirest.js
@@ -1,4 +1,5 @@
 var _ = require('./lodash'),
+  sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
 
@@ -15,7 +16,7 @@ var _ = require('./lodash'),
 function makeSnippet (request, indentString, options) {
   var snippet = 'var unirest = require(\'unirest\');\n';
 
-  snippet += `var req = unirest('${request.method}', '${request.url.toString()}')\n`;
+  snippet += `var req = unirest('${request.method}', '${sanitize(request.url.toString())}')\n`;
   if (request.body && !request.headers.has('Content-Type')) {
     if (request.body.mode === 'file') {
       request.addHeader({

--- a/codegens/nodejs-unirest/test/unit/snippet.test.js
+++ b/codegens/nodejs-unirest/test/unit/snippet.test.js
@@ -208,7 +208,7 @@ describe('nodejs unirest convert function', function () {
           'query': [
             {
               'key': 'query1',
-              'value': 'b\'b'
+              'value': "b'b" // eslint-disable-line quotes
             },
             {
               'key': 'query2',

--- a/codegens/nodejs-unirest/test/unit/snippet.test.js
+++ b/codegens/nodejs-unirest/test/unit/snippet.test.js
@@ -190,6 +190,42 @@ describe('nodejs unirest convert function', function () {
         expect(snippet).to.include('.attach(\'file\', \'/path/to/file\')');
       });
     });
+
+    it('should generate valid snippet for single/double quotes in url', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'https://postman-echo.com/get?query1=b\'b&query2=c"c',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ],
+          'query': [
+            {
+              'key': 'query1',
+              'value': 'b\'b'
+            },
+            {
+              'key': 'query2',
+              'value': 'c"c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        // eslint-disable-next-line quotes
+        expect(snippet).to.include("'https://postman-echo.com/get?query1=b\\'b&query2=c\"c'");
+      });
+    });
   });
 
   describe('getOptions function', function () {

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -281,7 +281,7 @@ function convert (request, options, callback) {
   }
 
   if (_.includes(VALID_METHODS, request.method)) {
-    codeSnippet += `$response = Invoke-RestMethod '${request.url.toString()}' -Method '` +
+    codeSnippet += `$response = Invoke-RestMethod '${request.url.toString().replace(/'/g, '\'\'')}' -Method '` +
                         `${request.method}' -Headers $headers -Body $body`;
   }
   else {

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -421,6 +421,43 @@ describe('Powershell-restmethod converter', function () {
         expect(snippet).to.include('$multipartFile = \'/test3.txt\'');
       });
     });
+
+    it('should generate valid snippet for single/double quotes in url', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'https://postman-echo.com/get?query1=b\'b&query2=c"c',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ],
+          'query': [
+            {
+              'key': 'query1',
+              'value': 'b\'b'
+            },
+            {
+              'key': 'query2',
+              'value': 'c"c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        // An extra single quote is placed before a single quote to escape a single quote inside a single quoted string
+        // eslint-disable-next-line quotes
+        expect(snippet).to.include("'https://postman-echo.com/get?query1=b''b&query2=c\"c'");
+      });
+    });
   });
 
   describe('getOptions function', function () {

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -439,7 +439,7 @@ describe('Powershell-restmethod converter', function () {
           'query': [
             {
               'key': 'query1',
-              'value': 'b\'b'
+              'value': "b'b" // eslint-disable-line quotes
             },
             {
               'key': 'query2',

--- a/codegens/shell-wget/lib/shell-wget.js
+++ b/codegens/shell-wget/lib/shell-wget.js
@@ -154,7 +154,7 @@ self = module.exports = {
     }
     snippet += `${getHeaders(request, indentation)}\n`;
     snippet += `${parseBody(request.toJSON(), options.trimRequestBody, indentation)}`;
-    snippet += `${indentation} '${request.url.toString()}'`;
+    snippet += `${indentation} '${sanitize(request.url.toString(), 'url')}'`;
 
     return callback(null, snippet);
   }

--- a/codegens/shell-wget/lib/util/sanitize.js
+++ b/codegens/shell-wget/lib/util/sanitize.js
@@ -26,6 +26,8 @@ module.exports = {
           return inputString.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
         case 'header':
           return inputString.replace(/'/g, '\'\\\'\'');
+        case 'url':
+          return inputString.replace(/'/g, '\'\\\'\'');
         default:
           return inputString.replace(/'/g, '\'');
       }

--- a/codegens/shell-wget/test/unit/converter.test.js
+++ b/codegens/shell-wget/test/unit/converter.test.js
@@ -169,7 +169,7 @@ describe('Shell-Wget converter', function () {
           'query': [
             {
               'key': 'query1',
-              'value': 'b\'b'
+              'value': "b'b" // eslint-disable-line quotes
             },
             {
               'key': 'query2',

--- a/codegens/shell-wget/test/unit/converter.test.js
+++ b/codegens/shell-wget/test/unit/converter.test.js
@@ -151,6 +151,44 @@ describe('Shell-Wget converter', function () {
         expect(snippet).to.include('text key=text value');
       });
     });
+
+    it('should generate valid snippet for single/double quotes in url', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'https://postman-echo.com/get?query1=b\'b&query2=c"c',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ],
+          'query': [
+            {
+              'key': 'query1',
+              'value': 'b\'b'
+            },
+            {
+              'key': 'query2',
+              'value': 'c"c'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        // To escape a single quotes inside a single quoted string, '\'(all 3 characters)
+        // needs to be added before '(single quote)
+        // eslint-disable-next-line quotes
+        expect(snippet).to.include("'https://postman-echo.com/get?query1=b'\\''b&query2=c\"c'");
+      });
+    });
   });
 
   describe('getOptions function', function () {

--- a/test/codegen/newman/fixtures/basicCollection.json
+++ b/test/codegen/newman/fixtures/basicCollection.json
@@ -183,34 +183,6 @@
 			"response": []
 		},
 		{
-			"name": "GET Request with single quotes and double quotes in query",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "https://postman-echo.com/get?query1=b'b&query2=c\"c",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"get"
-					],
-					"query": [
-						{
-							"key": "query1",
-							"value": "b'b"
-						},
-						{
-							"key": "query2",
-							"value": "c\"c"
-						}
-					]
-				}
-			}
-		},
-		{
 			"name": "POST Raw Text",
 			"event": [
 				{

--- a/test/codegen/newman/fixtures/basicCollection.json
+++ b/test/codegen/newman/fixtures/basicCollection.json
@@ -183,6 +183,34 @@
 			"response": []
 		},
 		{
+			"name": "GET Request with single quotes and double quotes in query",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/get?query1=b'b&query2=c\"c",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"get"
+					],
+					"query": [
+						{
+							"key": "query1",
+							"value": "b'b"
+						},
+						{
+							"key": "query2",
+							"value": "c\"c"
+						}
+					]
+				}
+			}
+		},
+		{
 			"name": "POST Raw Text",
 			"event": [
 				{


### PR DESCRIPTION
Need escaping of single/double quotes in url as query params can contain them. 
This PR fixes #132. 
Added the fixes in following codegens:
- nodejs-native
- nodejs-unirest
- javascript-fetch
- shell-wget
- powershell-restmethod

Added regression test for the same in basicCollection.
