### PR TITLE
Fixed multiple headers with same name issue in js-jquery

### DIFF
--- a/codegens/js-jquery/lib/js-jquery.js
+++ b/codegens/js-jquery/lib/js-jquery.js
@@ -14,14 +14,21 @@ var _ = require('./lodash'),
      * @returns {String} - request headers in the desired format
      */
 function getHeaders (request, indent) {
-  var headerArray = request.toJSON().header,
+  var headerObject = request.getHeaders({ enabled: true}),
     headerMap;
 
-  if (!_.isEmpty(headerArray)) {
-    headerArray = _.reject(headerArray, 'disabled');
-    headerMap = _.map(headerArray, function (header) {
-      return `${indent.repeat(2)}"${sanitize(header.key, 'header', true)}": ` +
-          `"${sanitize(header.value, 'header')}"`;
+  if (!_.isEmpty(headerObject)) {
+    headerMap = _.map(Object.keys(headerObject), function (key) {
+      if (Array.isArray(headerObject[key])) {
+        var headerValues = [];
+        _.forEach(headerObject[key], (value) => {
+          headerValues.push(`"${sanitize(value, 'header')}"`);
+        });
+        return `${indent.repeat(2)}"${sanitize(key, 'header', true)}": ` +
+          `[${headerValues.join(', ')}]`;
+      }
+      return `${indent.repeat(2)}"${sanitize(key, 'header', true)}": ` +
+          `"${sanitize(headerObject[key], 'header')}"`;
     });
     return `${indent}"headers": {\n${headerMap.join(',\n')}\n${indent}},\n`;
   }

--- a/codegens/js-jquery/test/unit/converter.test.js
+++ b/codegens/js-jquery/test/unit/converter.test.js
@@ -231,4 +231,41 @@ describe('jQuery converter', function () {
       expect(snippet).to.include('"invalid src", fileInput.files[0], "file"');
     });
   });
+
+  it('should generate valid snippet for multiple headers with same name', function () {
+    var request = new sdk.Request({
+      'method': 'POST',
+      'header': [
+        {
+          'key': 'sample_key',
+          'value': 'value1'
+        },
+        {
+          'key': 'sample_key',
+          'value': 'value2'
+        }
+      ],
+      'url': {
+        'raw': 'https://postman-echo.com/get',
+        'protocol': 'https',
+        'host': [
+          'postman-echo',
+          'com'
+        ],
+        'path': [
+          'get'
+        ]
+      }
+    });
+
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      expect(snippet).to.include('"sample_key": ["value1", "value2"]');
+      expect(snippet).to.not.include('"sample_key": "value1"');
+      expect(snippet).to.not.include('"sample_key": "value2"');
+    });
+  });
 });


### PR DESCRIPTION
<img width="400" alt="Screenshot 2019-11-12 at 12 07 24 PM" src="https://user-images.githubusercontent.com/20665864/69527450-5b528d00-0f92-11ea-877f-f2dfc77be0ca.png">
Multiple headers with the same name caused creating an invalid snippet, because of the same keys in an object. The headers with the same name will be clubbed and kept in an array, i.e.

```"sdf": ["sdf", "sdsfg"]```

This fixes #124 