### PR TITLE
ignore unused `resp` variable on line 392

### DIFF
--- a/codegens/ocaml-cohttp/lib/ocaml.js
+++ b/codegens/ocaml-cohttp/lib/ocaml.js
@@ -389,7 +389,7 @@ self = module.exports = {
     if (bodySnippet !== '') {
       codeSnippet += '~body ';
     }
-    codeSnippet += `${methodArg} uri >>= fun (resp, body) ->\n`;
+    codeSnippet += `${methodArg} uri >>= fun (_resp, body) ->\n`;
     codeSnippet += `${indent}body |> Cohttp_lwt.Body.to_string >|= fun body -> body\n\n`;
     codeSnippet += 'let () =\n';
     codeSnippet += `${indent}let respBody = Lwt_main.run reqBody in\n`;


### PR DESCRIPTION
Snippet doesn't compile with unused `rest` command. Snippet should now be:

```ocaml
let reqBody =
  let uri = Uri.of_string "https://api.twitter.com/labs/1/users?usernames=TwitterDev&format=detailed" in
  Client.call ~headers:headers `GET uri >>= fun (_resp, body) ->
  body |> Cohttp_lwt.Body.to_string >|= fun body -> body
```