### PR TITLE
Fix: Golang unused variable that causes errors (issue #153)

### DIFF
--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -280,7 +280,9 @@ self = module.exports = {
       codeSnippet += `${indent}req.Header.Set("Content-Type", writer.FormDataContentType())\n`;
     }
     responseSnippet = `${indent}res, err := client.Do(req)\n`;
+    responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n${indent}}\n`;
     responseSnippet += `${indent}defer res.Body.Close()\n${indent}body, err := ioutil.ReadAll(res.Body)\n\n`;
+    responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n${indent}}\n`;
     responseSnippet += `${indent}fmt.Println(string(body))\n}`;
 
     codeSnippet += responseSnippet;

--- a/codegens/golang/test/unit/convert.test.js
+++ b/codegens/golang/test/unit/convert.test.js
@@ -165,5 +165,29 @@ describe('Golang convert function', function () {
         expect(snippet).to.include('writer.CreateFormFile("invalid src",filepath.Base("/path/to/file"))');
       });
     });
+
+    it('should not ignore unused error variable', function () {
+      request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'https://google.com',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        var errDeclared = snippet.split('err :=').length - 1,
+          errHandled = snippet.split('fmt.Println(err)').length - 1;
+        expect(errDeclared).to.eql(errHandled);
+      });
+    });
   });
 });


### PR DESCRIPTION
The `golang` force to use all defined variables, otherwise, the compiler will output an error and refuse to compile.

There're two ways to fix it.
The first is to `Printf` the error to the console, so that the user will know what had happened by reading the console stdout output. (I used this method)
The second is to ignore the unused variables by naming a variable to `_`, This method will ignore the error, and user will never know what happened, this may confuse some user when something wrong happened.

So, I just fix it by use the variable to output the error, and the snippet can pass golang's compiler.