### PR TITLE
Fix issue #158

### DIFF
--- a/codegens/csharp-restsharp/lib/parseRequest.js
+++ b/codegens/csharp-restsharp/lib/parseRequest.js
@@ -106,7 +106,11 @@ function parseHeader (requestJson) {
 
   return requestJson.header.reduce((headerSnippet, header) => {
     if (!header.disabled) {
-      headerSnippet += `request.AddHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
+      if (sanitize(header.key, true).toLowerCase() === 'user-agent') {
+        headerSnippet += `client.UserAgent = "${sanitize(header.value)}";\n`;
+      } else {
+        headerSnippet += `request.AddHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
+      }
     }
     return headerSnippet;
   }, '');

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -257,6 +257,33 @@ describe('csharp restsharp function', function () {
       sanitizedOptions = sanitizeOptions(testOptions, getOptions());
       expect(sanitizedOptions).to.deep.equal(testOptions);
     });
+
+    it('should use client.UserAgent instead of AddHeader function', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'User-Agent',
+            'value': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15'
+          }
+        ],
+        'url': {
+          'raw': 'https://google.com',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('client.UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15";');
+      });
+    });
   });
 
 });


### PR DESCRIPTION
I fixed issue #158 by changing the C# RestSharp API .

As He says, the 
```c#
request.AddHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0");
```
doesn't work and will be overwritten to a default UA, the official solution is to use 
```C#
client.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0";
```
Instead of Add Header.

So I just fix it by checking whether a Header's key equals to `User-Agent`, If so, output the `client.UserAgent = "..."`, otherwise, output the `request.AddHeader(..., ...)`.

So It will work and fix the issues.