### PR TITLE
Fix csharp-restsharp user agent header issue

### DIFF
--- a/codegens/csharp-restsharp/lib/parseRequest.js
+++ b/codegens/csharp-restsharp/lib/parseRequest.js
@@ -108,7 +108,8 @@ function parseHeader (requestJson) {
     if (!header.disabled) {
       if (sanitize(header.key, true).toLowerCase() === 'user-agent') {
         headerSnippet += `client.UserAgent = "${sanitize(header.value)}";\n`;
-      } else {
+      }
+      else {
         headerSnippet += `request.AddHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
       }
     }

--- a/codegens/csharp-restsharp/lib/parseRequest.js
+++ b/codegens/csharp-restsharp/lib/parseRequest.js
@@ -106,7 +106,11 @@ function parseHeader (requestJson) {
 
   return requestJson.header.reduce((headerSnippet, header) => {
     if (!header.disabled) {
-      headerSnippet += `request.AddHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
+      if (sanitize(header.key, true).toLowerCase() === 'user-agent') {
+        headerSnippet += `client.UserAgent = "${sanitize(header.value)}";\n`;
+      } else {
+        headerSnippet += `request.AddHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
+      }
     }
     return headerSnippet;
   }, '');

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -3,7 +3,6 @@ var expect = require('chai').expect,
   convert = require('../../lib/index').convert,
   mainCollection = require('./fixtures/testcollection/collection.json'),
   testCollection = require('./fixtures/testcollection/collectionForEdge.json'),
-  uaTest = require('./fixtures/testUA.json'),
   getOptions = require('../../lib/index').getOptions,
   testResponse = require('./fixtures/testresponse.json'),
   sanitize = require('../../lib/util').sanitize,
@@ -260,12 +259,15 @@ describe('csharp restsharp function', function () {
     });
 
     it('should use client.UserAgent instead of AddHeader function', function () {
+      const sampleUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15';
+      const expectValue = `client.UserAgent = \"${sampleUA}\";`;
+      
       var request = new sdk.Request({
         'method': 'GET',
         'header': [
           {
             'key': 'User-Agent',
-            'value': uaTest.sample
+            'value': sampleUA
           }
         ],
         'url': {
@@ -282,7 +284,7 @@ describe('csharp restsharp function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include(uaTest.expect);
+        expect(snippet).to.include(expectValue);
       });
     });
   });

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -162,6 +162,36 @@ describe('csharp restsharp function', function () {
         expect(snippet).to.include('request.AddFile("invalid src", "/path/to/file"');
       });
     });
+
+    it('should use client.UserAgent instead of AddHeader function', function () {
+      const sampleUA = 'Safari/605.1.15';
+      const expectValue = 'client.UserAgent = "Safari/605.1.15";';
+
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'User-Agent',
+            'value': sampleUA
+          }
+        ],
+        'url': {
+          'raw': 'https://google.com',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include(expectValue);
+      });
+    });
   });
 
   describe('getOptions function', function () {
@@ -256,36 +286,6 @@ describe('csharp restsharp function', function () {
       testOptions.includeBoilerplate = true;
       sanitizedOptions = sanitizeOptions(testOptions, getOptions());
       expect(sanitizedOptions).to.deep.equal(testOptions);
-    });
-
-    it('should use client.UserAgent instead of AddHeader function', function () {
-      const sampleUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15';
-      const expectValue = `client.UserAgent = \"${sampleUA}\";`;
-      
-      var request = new sdk.Request({
-        'method': 'GET',
-        'header': [
-          {
-            'key': 'User-Agent',
-            'value': sampleUA
-          }
-        ],
-        'url': {
-          'raw': 'https://google.com',
-          'protocol': 'https',
-          'host': [
-            'google',
-            'com'
-          ]
-        }
-      });
-      convert(request, {}, function (error, snippet) {
-        if (error) {
-          expect.fail(null, null, error);
-        }
-        expect(snippet).to.be.a('string');
-        expect(snippet).to.include(expectValue);
-      });
     });
   });
 

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -164,8 +164,8 @@ describe('csharp restsharp function', function () {
     });
 
     it('should use client.UserAgent instead of AddHeader function', function () {
-      const sampleUA = 'Safari/605.1.15';
-      const expectValue = 'client.UserAgent = "Safari/605.1.15";';
+      const sampleUA = 'Safari/605.1.15',
+        expectValue = `client.UserAgent = "${sampleUA}";`;
 
       var request = new sdk.Request({
         'method': 'GET',

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -257,6 +257,33 @@ describe('csharp restsharp function', function () {
       sanitizedOptions = sanitizeOptions(testOptions, getOptions());
       expect(sanitizedOptions).to.deep.equal(testOptions);
     });
+
+    it('should use client.UserAgent instead of AddHeader function', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'User-Agent',
+            'value': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15'
+          }
+        ],
+        'url': {
+          'raw': 'https://google.com',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('client.UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15";');
+      });
+    });
   });
 
 });

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -3,6 +3,7 @@ var expect = require('chai').expect,
   convert = require('../../lib/index').convert,
   mainCollection = require('./fixtures/testcollection/collection.json'),
   testCollection = require('./fixtures/testcollection/collectionForEdge.json'),
+  uaTest = require('./fixtures/testUA.json'),
   getOptions = require('../../lib/index').getOptions,
   testResponse = require('./fixtures/testresponse.json'),
   sanitize = require('../../lib/util').sanitize,
@@ -264,7 +265,7 @@ describe('csharp restsharp function', function () {
         'header': [
           {
             'key': 'User-Agent',
-            'value': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15'
+            'value': uaTest.sample
           }
         ],
         'url': {
@@ -281,7 +282,7 @@ describe('csharp restsharp function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('client.UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15";');
+        expect(snippet).to.include(uaTest.expect);
       });
     });
   });

--- a/codegens/csharp-restsharp/test/unit/fixtures/testUA.json
+++ b/codegens/csharp-restsharp/test/unit/fixtures/testUA.json
@@ -1,4 +1,0 @@
-{
-    "sample": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
-    "expect": "client.UserAgent = \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15\";"
-}

--- a/codegens/csharp-restsharp/test/unit/fixtures/testUA.json
+++ b/codegens/csharp-restsharp/test/unit/fixtures/testUA.json
@@ -1,0 +1,4 @@
+{
+    "sample": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15",
+    "expect": "client.UserAgent = \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Safari/605.1.15\";"
+}


### PR DESCRIPTION
I fixed issue #158 by changing the C# RestSharp API .

As He says, the 
```c#
request.AddHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0");
```
doesn't work and will be overwritten to a default UA, the official solution is to use 
```C#
client.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0";
```
Instead of Add Header.

So I just fix it by checking whether a Header's key equals to `User-Agent`, If so, output the `client.UserAgent = "..."`, otherwise, output the `request.AddHeader(..., ...)`.

So It will work and fix the issues.

@shreys7 I added an extra unit test for my fix. This is my first time contributing to the open source community, thank you for your guidance!