### PR TITLE
Move test file creation step from ci-requirements script to test script for form data testing

### DIFF
--- a/npm/addPathToFormdataFile.js
+++ b/npm/addPathToFormdataFile.js
@@ -3,9 +3,9 @@ var path = require('path'),
 let collectionPath = path.resolve(__dirname, '../test/codegen/newman/fixtures/formdataFileCollection.json'),
   collection = require(collectionPath),
   formdata = collection.item[0].request.body.formdata;
-formdata[0].src = path.resolve(__dirname, '../test1.txt');
-formdata[1].src[0] = path.resolve(__dirname, '../test2.txt');
-formdata[1].src[1] = path.resolve(__dirname, '../test3.txt');
+formdata[0].src = path.resolve(__dirname, '../dummyFile1.txt');
+formdata[1].src[0] = path.resolve(__dirname, '../dummyFile2.txt');
+formdata[1].src[1] = path.resolve(__dirname, '../dummyFile3.txt');
 
 fs.writeFileSync(collectionPath, JSON.stringify(collection, null, 2), function (error) {
   if (error) {

--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 set -ev; # stop on error
-echo "Creating test files and adding paths to collection for testing form data file uploads"
-pushd /home/travis/build/postmanlabs/postman-code-generators/ &>/dev/null;
-  echo "Sample file 1" >> test1.txt;
-  echo "Sample file 2" >> test2.txt;
-  echo "Sample file 3" >> test3.txt;
-  node ./npm/addPathToFormdataFile.js
-popd &>/dev/null;
 
 echo "Installing dependencies required for tests in codegens/java-okhttp"
 pushd ./codegens/java-okhttp &>/dev/null;

--- a/npm/test.sh
+++ b/npm/test.sh
@@ -101,4 +101,5 @@ else
 fi
 
 echo "Deleting test files used for testing form data file uploads"
-rm dummyFile1.txt dummyFile2.txt dummyFile3.txt;
+# Also handles the case when files does not exist
+rm -f -- dummyFile1.txt dummyFile2.txt dummyFile3.txt;

--- a/npm/test.sh
+++ b/npm/test.sh
@@ -14,9 +14,18 @@ fi
 popd &>/dev/null
 
 echo "Creating test files and adding paths to collection for testing form data file uploads"
-echo "Sample file 1" >> dummyFile1.txt;
-echo "Sample file 2" >> dummyFile2.txt;
-echo "Sample file 3" >> dummyFile3.txt;
+if [ ! -e dummyFile1.txt ];
+then 
+    echo "Sample file 1" >> dummyFile1.txt;
+fi
+if [ ! -e dummyFile2.txt ];
+then 
+    echo "Sample file 2" >> dummyFile2.txt;
+fi
+if [ ! -e dummyFile3.txt ];
+then 
+    echo "Sample file 3" >> dummyFile3.txt;
+fi
 node ./npm/addPathToFormdataFile.js
 
 echo "Running newman for common collection and storing results in newmanResponses.json"

--- a/npm/test.sh
+++ b/npm/test.sh
@@ -12,6 +12,13 @@ else
     exit 1;
 fi
 popd &>/dev/null
+
+echo "Creating test files and adding paths to collection for testing form data file uploads"
+echo "Sample file 1" >> dummyFile1.txt;
+echo "Sample file 2" >> dummyFile2.txt;
+echo "Sample file 3" >> dummyFile3.txt;
+node ./npm/addPathToFormdataFile.js
+
 echo "Running newman for common collection and storing results in newmanResponses.json"
     node ./test/codegen/newman/runNewman.js
 
@@ -83,3 +90,6 @@ else
     done
 
 fi
+
+echo "Deleting test files used for testing form data file uploads"
+rm dummyFile1.txt dummyFile2.txt dummyFile3.txt;


### PR DESCRIPTION
Previously, the files required for testing form data file uploads were created using `ci-requirements.sh` step. This file is not run locally and hence would cause form-data tests to fail locally. This step has been removed from `ci-requirements.sh` file and moved to `test.sh` file.
This fixes #172 