### PR TITLE
Added ES6 feature support to NodeJS-Request codegen

### DIFF
--- a/codegens/nodejs-request/lib/request.js
+++ b/codegens/nodejs-request/lib/request.js
@@ -17,11 +17,12 @@ function makeSnippet (request, indentString, options) {
     optionsArray = [],
     isFormDataFile = false;
   if (options.ES6_enabled) {
-    snippet = 'let request = require(\'request\');\n';
+    snippet = 'const ';
   }
   else {
-    snippet = 'var request = require(\'request\');\n';
+    snippet = 'var ';
   }
+  snippet += 'request = require(\'request\');\n';
   if (request.body && request.body.mode === 'formdata') {
     _.forEach(request.body.toJSON().formdata, function (data) {
       if (!data.disabled && data.type === 'file') {
@@ -31,18 +32,20 @@ function makeSnippet (request, indentString, options) {
   }
   if (isFormDataFile) {
     if (options.ES6_enabled) {
-      snippet += 'let fs = require(\'fs\');\n';
+      snippet += 'const ';
     }
     else {
-      snippet += 'var fs = require(\'fs\');\n';
+      snippet += 'var ';
     }
+    snippet += 'fs = require(\'fs\');\n';
   }
   if (options.ES6_enabled) {
-    snippet += 'let options = {\n';
+    snippet += 'let ';
   }
   else {
-    snippet += 'var options = {\n';
+    snippet += 'var ';
   }
+  snippet += 'options = {\n';
 
   /**
      * creating string to represent options object using optionArray.join()
@@ -86,11 +89,12 @@ function makeSnippet (request, indentString, options) {
   snippet += optionsArray.join(',\n') + '\n';
   snippet += '};\n';
 
+  snippet += 'request(options, ';
   if (options.ES6_enabled) {
-    snippet += 'request(options, (error, response) => {\n';
+    snippet += '(error, response) => {\n';
   }
   else {
-    snippet += 'request(options, function (error, response) {\n';
+    snippet += 'function (error, response) {\n';
   }
   snippet += indentString + 'if (error) throw new Error(error);\n';
   snippet += indentString + 'console.log(response.body);\n';

--- a/codegens/nodejs-request/lib/request.js
+++ b/codegens/nodejs-request/lib/request.js
@@ -13,9 +13,15 @@ var _ = require('./lodash'),
  * @returns {String} - nodejs(request) code snippet for given request object
  */
 function makeSnippet (request, indentString, options) {
-  var snippet = 'var request = require(\'request\');\n',
+  var snippet,
     optionsArray = [],
     isFormDataFile = false;
+  if (options.ES6_enabled) {
+    snippet = 'let request = require(\'request\');\n';
+  }
+  else {
+    snippet = 'var request = require(\'request\');\n';
+  }
   if (request.body && request.body.mode === 'formdata') {
     _.forEach(request.body.toJSON().formdata, function (data) {
       if (!data.disabled && data.type === 'file') {
@@ -24,9 +30,19 @@ function makeSnippet (request, indentString, options) {
     });
   }
   if (isFormDataFile) {
-    snippet += 'var fs = require(\'fs\');\n';
+    if (options.ES6_enabled) {
+      snippet += 'let fs = require(\'fs\');\n';
+    }
+    else {
+      snippet += 'var fs = require(\'fs\');\n';
+    }
   }
-  snippet += 'var options = {\n';
+  if (options.ES6_enabled) {
+    snippet += 'let options = {\n';
+  }
+  else {
+    snippet += 'var options = {\n';
+  }
 
   /**
      * creating string to represent options object using optionArray.join()
@@ -70,7 +86,12 @@ function makeSnippet (request, indentString, options) {
   snippet += optionsArray.join(',\n') + '\n';
   snippet += '};\n';
 
-  snippet += 'request(options, function (error, response) { \n';
+  if (options.ES6_enabled) {
+    snippet += 'request(options, (error, response) => {\n';
+  }
+  else {
+    snippet += 'request(options, function (error, response) {\n';
+  }
   snippet += indentString + 'if (error) throw new Error(error);\n';
   snippet += indentString + 'console.log(response.body);\n';
   snippet += '});\n';
@@ -120,6 +141,13 @@ function getOptions () {
       type: 'boolean',
       default: false,
       description: 'Remove white space and additional lines that may affect the server\'s response'
+    },
+    {
+      name: 'Generate the code snippet with ES6 features',
+      id: 'ES6_enabled',
+      type: 'boolean',
+      default: false,
+      description: 'Allows the user to generate code snippet with latest EcmaScript 6 (ES6) features'
     }
   ];
 }
@@ -133,6 +161,7 @@ function getOptions () {
  * @param {String} options.indentCount - number of spaces or tabs for indentation.
  * @param {Boolean} options.followRedirect - whether to enable followredirect
  * @param {Boolean} options.trimRequestBody - whether to trim fields in request body or not
+ * @param {Boolean} options.ES6_enabled - whether to generate snippet with ES6 features
  * @param {Number} options.requestTimeout : time in milli-seconds after which request will bail out
  * @param {Function} callback - callback function with parameters (error, snippet)
  */

--- a/codegens/nodejs-request/lib/request.js
+++ b/codegens/nodejs-request/lib/request.js
@@ -147,11 +147,11 @@ function getOptions () {
       description: 'Remove white space and additional lines that may affect the server\'s response'
     },
     {
-      name: 'Generate the code snippet with ES6 features',
+      name: 'Enable ES6 features',
       id: 'ES6_enabled',
       type: 'boolean',
       default: false,
-      description: 'Allows the user to generate code snippet with latest EcmaScript 6 (ES6) features'
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }
   ];
 }

--- a/codegens/nodejs-request/test/newman/newman.test.js
+++ b/codegens/nodejs-request/test/newman/newman.test.js
@@ -11,4 +11,17 @@ describe('Convert for different types of request', function () {
     };
 
   runNewmanTest(convert, options, testConfig);
+
+  describe('Convert for request incorporating ES6 features', function () {
+    var options = {indentCount: 2, indentType: 'Space', ES6_enabled: true},
+      testConfig = {
+        compileScript: null,
+        runScript: 'node run.js',
+        fileName: 'run.js',
+        headerSnippet: '/* eslint-disable */\n'
+      };
+
+    runNewmanTest(convert, options, testConfig);
+  });
+
 });

--- a/codegens/nodejs-request/test/unit/snippet.test.js
+++ b/codegens/nodejs-request/test/unit/snippet.test.js
@@ -64,7 +64,7 @@ describe('nodejs-request convert function', function () {
 
         expect(snippet).to.be.a('string');
         snippetArray = snippet.split('\n');
-        expect(snippetArray[0]).to.equal('let request = require(\'request\');');
+        expect(snippetArray[0]).to.equal('const request = require(\'request\');');
         expect(snippetArray).to.include('let options = {');
         expect(snippetArray).to.include('request(options, (error, response) => {');
       });

--- a/codegens/nodejs-request/test/unit/snippet.test.js
+++ b/codegens/nodejs-request/test/unit/snippet.test.js
@@ -51,6 +51,25 @@ describe('nodejs-request convert function', function () {
       });
     });
 
+    it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
+      request = new sdk.Request(mainCollection.item[0].request);
+      options = {
+        ES6_enabled: true
+      };
+      convert(request, options, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+          return;
+        }
+
+        expect(snippet).to.be.a('string');
+        snippetArray = snippet.split('\n');
+        expect(snippetArray[0]).to.equal('let request = require(\'request\');');
+        expect(snippetArray).to.include('let options = {');
+        expect(snippetArray).to.include('request(options, (error, response) => {');
+      });
+    });
+
     it('should return snippet with followRedirect property set to ' +
         'false for no follow redirect', function () {
       request = new sdk.Request(mainCollection.item[0].request);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,7 +2303,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2324,12 +2325,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2344,17 +2347,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2471,7 +2477,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2483,6 +2490,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2497,6 +2505,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2504,12 +2513,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2528,6 +2539,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2608,7 +2620,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2620,6 +2633,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2705,7 +2719,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2741,6 +2756,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2760,6 +2776,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2803,12 +2820,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -62,10 +62,10 @@ const expectedOptions = {
       description: 'Display the requested data without showing the cURL progress meter or error messages'
     },
     ES6_enabled:{
-      name: 'Generate the code snippet with ES6 features',
+      name: 'Enable ES6 features',
       type: 'boolean',
       default: false,
-      description: 'Allows the user to generate code snippet with latest EcmaScript 6 (ES6) features'
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }
   },
   // Standard array of ids that should be used for options ids. Any new option should be updated here.

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -60,6 +60,12 @@ const expectedOptions = {
       type: 'boolean',
       default: false,
       description: 'Display the requested data without showing the cURL progress meter or error messages'
+    },
+    ES6_enabled:{
+      name: 'Generate the code snippet with ES6 features',
+      type: 'boolean',
+      default: false,
+      description: 'Allows the user to generate code snippet with latest EcmaScript 6 (ES6) features'
     }
   },
   // Standard array of ids that should be used for options ids. Any new option should be updated here.
@@ -75,7 +81,8 @@ const expectedOptions = {
     'followRedirect',
     'lineContinuationCharacter',
     'protocol',
-    'useMimeType'
+    'useMimeType',
+    'ES6_enabled'
   ],
   CODEGEN_ABS_PATH = `./codegens/${codegen}`;
 describe('Code-gen repository ' + codegen, function () {


### PR DESCRIPTION
**What it does**
It allows the user to generate the code snippet for NodeJS Request in ES6 format.
This is in response to issue #115 requested by one of the users.

**Changes I made**

- Registered a new parameter ES6_enabled in **`options()`** which allows the user to toggle between whether codegen generates snippet with ES6 features or not.

- By default ES6_enabled is set to `false`

- Also added the new created option parameter in **`structure.test.js`** file to register it as a valid option id.

- Added unit tests to verify the generated snippets.

**Follow Up**
This PR is first in the series of upcoming PRs which will add the feature of generating code snippet in ES6 notation with NodeJS. 
