### PR TITLE
Fixed test file path for formdataFileCollection

### DIFF
--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 set -ev; # stop on error
-echo "Creating test files and adding paths to collection for testing form data file uploads"
-pushd /home/travis/build/postmanlabs/postman-code-generators/ &>/dev/null;
-  echo "Sample file 1" >> test1.txt;
-  echo "Sample file 2" >> test2.txt;
-  echo "Sample file 3" >> test3.txt;
-  node ./npm/addPathToFormdataFile.js
-popd &>/dev/null;
 
 echo "Installing dependencies required for tests in codegens/java-okhttp"
 pushd ./codegens/java-okhttp &>/dev/null;

--- a/npm/test.sh
+++ b/npm/test.sh
@@ -12,6 +12,25 @@ else
     exit 1;
 fi
 popd &>/dev/null
+
+# Create sample files for uploading to formdataFileCollection fixture
+echo "Creating sample data files"
+if [ ! -e test1.txt ];
+then 
+    echo "Sample file 1" >> test1.txt;
+fi
+if [ ! -e test2.txt ];
+then 
+    echo "Sample file 2" >> test2.txt;
+fi
+if [ ! -e test3.txt ];
+then 
+    echo "Sample file 3" >> test3.txt;
+fi
+
+# Set the file path to formdataFileCollection
+node ./npm/addPathToFormdataFile.js
+
 echo "Running newman for common collection and storing results in newmanResponses.json"
     node ./test/codegen/newman/runNewman.js
 
@@ -83,3 +102,7 @@ else
     done
 
 fi
+
+#Delete the sample files after testing
+echo "Deleting test files used for testing form data file uploads"
+rm test1.txt test2.txt text3.txt;  


### PR DESCRIPTION
**What it does**
This PR fixes the issue #172 , which was causing the **`formdataFileCollection`** test to fail as the test file that was required to upload by the codegen does not exist.

**Changes I made**

- Added command to generate test files in **`test.sh`** with sample data before beginning the test, and once test is completed they must be deleted. 

- Removed it's equivalent command from **`ci-requirements.sh`** which was causing redundancy.

**Follow Up**
`N/A`

@umeshp7  @shreys7  Please review!