### PR TITLE
Added ES6 feature support to NodeJS Native codegen

### DIFF
--- a/codegens/nodejs-native/README.md
+++ b/codegens/nodejs-native/README.md
@@ -20,6 +20,7 @@ Convert function will take three parameters
     * `requestTimeout` : Integer denoting time after which the request will bail out in milli-seconds
     * `trimRequestBody` : Trim request body fields
     * `followRedirect` : Boolean denoting whether to redirect a request
+    * `ES6_enabled` : Boolean denoting whether to generate snippet with ES6 features
 
 * `callback`- callback function with first parameter as error and second parameter as string for code snippet
 

--- a/codegens/nodejs-native/lib/request.js
+++ b/codegens/nodejs-native/lib/request.js
@@ -24,15 +24,11 @@ function makeSnippet (request, indentString, options) {
   else {
     snippet = 'var ';
   }
-  snippet += `${nativeModule} = require('${nativeModule}');\n`;
   if (options.followRedirect) {
-    if (options.ES6_enabled) {
-      snippet = 'const ';
-    }
-    else {
-      snippet = 'var ';
-    }
     snippet += `${nativeModule} = require('follow-redirects').${nativeModule};\n`;
+  }
+  else {
+    snippet += `${nativeModule} = require('${nativeModule}');\n`;
   }
   if (options.ES6_enabled) {
     snippet += 'const ';

--- a/codegens/nodejs-native/lib/request.js
+++ b/codegens/nodejs-native/lib/request.js
@@ -15,19 +15,48 @@ var self;
  */
 function makeSnippet (request, indentString, options) {
   var nativeModule = (request.url.protocol === 'http' ? 'http' : 'https'),
-    snippet = `var ${nativeModule} = require('${nativeModule}');\n`,
+    snippet,
     optionsArray = [],
     postData = '';
-
+  if (options.ES6_enabled) {
+    snippet = 'const ';
+  }
+  else {
+    snippet = 'var ';
+  }
+  snippet += `${nativeModule} = require('${nativeModule}');\n`;
   if (options.followRedirect) {
-    snippet = `var ${nativeModule} = require('follow-redirects').${nativeModule};\n`;
+    if (options.ES6_enabled) {
+      snippet = 'const ';
+    }
+    else {
+      snippet = 'var ';
+    }
+    snippet += `${nativeModule} = require('follow-redirects').${nativeModule};\n`;
   }
-  snippet += 'var fs = require(\'fs\');\n\n';
+  if (options.ES6_enabled) {
+    snippet += 'const ';
+  }
+  else {
+    snippet += 'var ';
+  }
+  snippet += 'fs = require(\'fs\');\n\n';
   if (_.get(request, 'body.mode') && request.body.mode === 'urlencoded') {
-    snippet += 'var qs = require(\'querystring\');\n\n';
+    if (options.ES6_enabled) {
+      snippet += 'const ';
+    }
+    else {
+      snippet += 'var ';
+    }
+    snippet += 'qs = require(\'querystring\');\n\n';
   }
-
-  snippet += 'var options = {\n';
+  if (options.ES6_enabled) {
+    snippet += 'let ';
+  }
+  else {
+    snippet += 'var ';
+  }
+  snippet += 'options = {\n';
 
   /**
      * creating string to represent options object using optionArray.join()
@@ -117,27 +146,55 @@ function makeSnippet (request, indentString, options) {
 
   snippet += optionsArray.join(',\n') + '\n';
   snippet += '};\n\n';
-
-  snippet += `var req = ${nativeModule}.request(options, function (res) {\n`;
-
-  snippet += indentString + 'var chunks = [];\n\n';
-  snippet += indentString + 'res.on("data", function (chunk) {\n';
+  if (options.ES6_enabled) {
+    snippet += 'const ';
+  }
+  else {
+    snippet += 'var ';
+  }
+  snippet += `req = ${nativeModule}.request(options, `;
+  if (options.ES6_enabled) {
+    snippet += '(res) => {\n';
+    snippet += indentString + 'let chunks = [];\n\n';
+    snippet += indentString + 'res.on("data", (chunk) => {\n';
+  }
+  else {
+    snippet += 'function (res) {\n';
+    snippet += indentString + 'var chunks = [];\n\n';
+    snippet += indentString + 'res.on("data", function (chunk) {\n';
+  }
   snippet += indentString.repeat(2) + 'chunks.push(chunk);\n';
   snippet += indentString + '});\n\n';
 
-  snippet += indentString + 'res.on("end", function (chunk) {\n';
-  snippet += indentString.repeat(2) + 'var body = Buffer.concat(chunks);\n';
+  if (options.ES6_enabled) {
+    snippet += indentString + 'res.on("end", (chunk) => {\n';
+    snippet += indentString.repeat(2) + 'let body = Buffer.concat(chunks);\n';
+  }
+  else {
+    snippet += indentString + 'res.on("end", function (chunk) {\n';
+    snippet += indentString.repeat(2) + 'var body = Buffer.concat(chunks);\n';
+  }
   snippet += indentString.repeat(2) + 'console.log(body.toString());\n';
   snippet += indentString + '});\n\n';
+  if (options.ES6_enabled) {
+    snippet += indentString + 'res.on("error", (error) => {\n';
+  }
+  else {
+    snippet += indentString + 'res.on("error", function (error) {\n';
+  }
 
-  snippet += indentString + 'res.on("error", function (error) {\n';
   snippet += indentString.repeat(2) + 'console.error(error);\n';
   snippet += indentString + '});\n';
-
   snippet += '});\n\n';
 
   if (request.body && !(_.isEmpty(request.body)) && postData.length) {
-    snippet += `var postData = ${postData};\n\n`;
+    if (options.ES6_enabled) {
+      snippet += 'let ';
+    }
+    else {
+      snippet += 'var ';
+    }
+    snippet += `postData = ${postData};\n\n`;
 
     if (request.method === 'DELETE') {
       snippet += 'req.setHeader(\'Content-Length\', postData.length);\n\n';
@@ -170,6 +227,7 @@ function makeSnippet (request, indentString, options) {
  * @param {String} options.indentCount - number of spaces or tabs for indentation.
  * @param {Boolean} options.followRedirect - whether to enable followredirect
  * @param {Boolean} options.trimRequestBody - whether to trim fields in request body or not
+ * @param {Boolean} options.ES6_enabled - whether to generate snippet with ES6 features
  * @param {Number} options.requestTimeout : time in milli-seconds after which request will bail out
  * @param {Function} callback - callback function with parameters (error, snippet)
  */
@@ -216,6 +274,13 @@ self = module.exports = {
       type: 'boolean',
       default: false,
       description: 'Remove white space and additional lines that may affect the server\'s response'
+    },
+    {
+      name: 'Enable ES6 features',
+      id: 'ES6_enabled',
+      type: 'boolean',
+      default: false,
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }];
   },
 

--- a/codegens/nodejs-native/test/newman/newman.test.js
+++ b/codegens/nodejs-native/test/newman/newman.test.js
@@ -11,4 +11,16 @@ describe('Convert for different types of request', function () {
     };
 
   runNewmanTest(convert, options, testConfig);
+
+  describe('Convert for request incorporating ES6 features', function () {
+    var options = {indentCount: 2, indentType: 'Space', ES6_enabled: true},
+      testConfig = {
+        compileScript: null,
+        runScript: 'node run.js',
+        fileName: 'run.js',
+        headerSnippet: '/* eslint-disable */\n'
+      };
+
+    runNewmanTest(convert, options, testConfig);
+  });
 });

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -94,6 +94,43 @@ describe('nodejs-native convert function', function () {
       expect(snippet).to.include('\'key_containing_whitespaces\': \'  value_containing_whitespaces  \'');
     });
   });
+
+  it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
+    var request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'lorem',
+            'value': 'lorem_ipsum'
+          }
+        ],
+        'url': {
+          'raw': 'https://google.com',
+          'protocol': 'https',
+          'host': [
+            'google',
+            'com'
+          ]
+        }
+      }),
+      nativeModule = (request.url.protocol === 'http' ? 'http' : 'https'),
+      snippetArray;
+    convert(request, {'followRedirect': true, 'ES6_enabled': true}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      snippetArray = snippet.split('\n');
+      expect(snippetArray[0]).to.equal(`const ${nativeModule} = require('follow-redirects').${nativeModule};`);
+      expect(snippetArray).to.include('const fs = require(\'fs\');');
+      expect(snippetArray).to.include('let options = {');
+      expect(snippetArray).to.include(`const req = ${nativeModule}.request(options, (res) => {`);
+      expect(snippetArray).to.include('  res.on("data", (chunk) => {');
+      expect(snippetArray).to.include('  res.on("end", (chunk) => {');
+      expect(snippetArray).to.include('  res.on("error", (error) => {');
+    });
+  });
+
   it('should include JSON.stringify in the snippet for raw json bodies', function () {
     var request = new sdk.Request({
       'method': 'POST',

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -97,7 +97,7 @@ describe('nodejs-native convert function', function () {
 
   it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
     var request = new sdk.Request({
-        'method': 'GET',
+        'method': 'POST',
         'header': [
           {
             'key': 'lorem',
@@ -105,15 +105,20 @@ describe('nodejs-native convert function', function () {
           }
         ],
         'url': {
-          'raw': 'https://google.com',
-          'protocol': 'https',
+          'raw': 'http://httpbin.org/post',
+          'protocol': 'http',
           'host': [
-            'google',
-            'com'
+            'httpbin',
+            'org'
           ]
+        },
+        'body': {
+          'mode': 'urlencoded',
+          'urlencoded': {
+            'title': 'foo-bar'
+          }
         }
       }),
-      nativeModule = (request.url.protocol === 'http' ? 'http' : 'https'),
       snippetArray;
     convert(request, {'followRedirect': true, 'ES6_enabled': true}, function (error, snippet) {
       if (error) {
@@ -121,12 +126,15 @@ describe('nodejs-native convert function', function () {
       }
       expect(snippet).to.be.a('string');
       snippetArray = snippet.split('\n');
-      expect(snippetArray[0]).to.equal(`const ${nativeModule} = require('follow-redirects').${nativeModule};`);
+      expect(snippetArray[0]).to.equal('const http = require(\'follow-redirects\').http;');
       expect(snippetArray).to.include('const fs = require(\'fs\');');
+      expect(snippetArray).to.include('const qs = require(\'querystring\');');
       expect(snippetArray).to.include('let options = {');
-      expect(snippetArray).to.include(`const req = ${nativeModule}.request(options, (res) => {`);
+      expect(snippetArray).to.include('const req = http.request(options, (res) => {');
+      expect(snippetArray).to.include('  let chunks = [];');
       expect(snippetArray).to.include('  res.on("data", (chunk) => {');
       expect(snippetArray).to.include('  res.on("end", (chunk) => {');
+      expect(snippetArray).to.include('    let body = Buffer.concat(chunks);');
       expect(snippetArray).to.include('  res.on("error", (error) => {');
     });
   });

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -60,6 +60,12 @@ const expectedOptions = {
       type: 'boolean',
       default: false,
       description: 'Display the requested data without showing the cURL progress meter or error messages'
+    },
+    ES6_enabled:{
+      name: 'Enable ES6 features',
+      type: 'boolean',
+      default: false,
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }
   },
   // Standard array of ids that should be used for options ids. Any new option should be updated here.
@@ -75,7 +81,8 @@ const expectedOptions = {
     'followRedirect',
     'lineContinuationCharacter',
     'protocol',
-    'useMimeType'
+    'useMimeType',
+    'ES6_enabled'
   ],
   CODEGEN_ABS_PATH = `./codegens/${codegen}`;
 describe('Code-gen repository ' + codegen, function () {


### PR DESCRIPTION
 **What this PR does**
It allows the user to generate the code snippet for NodeJS Native in ES6 format.
This is in response to issue #115  requested by one of the users.

**Changes you made**

- Registered a new parameter ES6_enabled in **`options()`** which allows the user to toggle between whether codegen generates snippet with ES6 features or not.

- By default ES6_enabled is set to `false`

- Also added the newly created option parameter in **`structure.test.js`** file to register it as a valid option id.

- Added unit tests to verify the generated snippets in **snippet.test.js**

- Added a new mocha test suite to verify that the generated snippet is runnable in **newman.test.js.**

- Updated the **readme.md** file with new option parameter.

**Screenshot/ CodeSnippet**
Not required

**Test Configuration**:

- Added a unit test to check the snippet generated

- Added a new block of mocha test inside the main suite to verify that the snippet produced is runnable.

**Follow up**
Not required

*Thanks for contributing!* ❤️