### PR TITLE
Added ES6 feature support to NodeJS Unirest codegen

### DIFF
--- a/codegens/nodejs-unirest/README.md
+++ b/codegens/nodejs-unirest/README.md
@@ -18,6 +18,7 @@ Convert function will take three parameters
     * `requestTimeout` : Integer denoting time after which the request will bail out in milli-seconds
     * `trimRequestBody` : Trim request body fields
     * `followRedirect` : Boolean denoting whether to redirect a request
+    * `ES6_enabled` : Boolean denoting whether to generate snippet with ES6 features
 
 * `callback`- callback function with first parameter as error and second parameter as string for code snippet
 
@@ -26,7 +27,8 @@ Convert function will take three parameters
 var request = new sdk.Request('www.google.com'),  //using postman sdk to create request  
     options = {
         indentType: 'Space',
-        indentCount: 2
+        indentCount: 2,
+        ES6_enabled: true
     };
 convert(request, options, function(error, snippet) {
     if (error) {

--- a/codegens/nodejs-unirest/lib/unirest.js
+++ b/codegens/nodejs-unirest/lib/unirest.js
@@ -14,9 +14,21 @@ var _ = require('./lodash'),
  * @returns {String} - nodejs(unirest) code snippet for given request object
  */
 function makeSnippet (request, indentString, options) {
-  var snippet = 'var unirest = require(\'unirest\');\n';
-
-  snippet += `var req = unirest('${request.method}', '${sanitize(request.url.toString())}')\n`;
+  var snippet;
+  if (options.ES6_enabled) {
+    snippet = 'const ';
+  }
+  else {
+    snippet = 'var ';
+  }
+  snippet += 'unirest = require(\'unirest\');\n';
+  if (options.ES6_enabled) {
+    snippet += 'const ';
+  }
+  else {
+    snippet += 'var ';
+  }
+  snippet += `req = unirest('${request.method}', '${sanitize(request.url.toString())}')\n`;
   if (request.body && !request.headers.has('Content-Type')) {
     if (request.body.mode === 'file') {
       request.addHeader({
@@ -80,13 +92,17 @@ function makeSnippet (request, indentString, options) {
       request.headers.get('Content-Type'));
   }
   if (options.requestTimeout) {
-    snippet += indentString + `.timeout(${options.requestTimeout})`;
+    snippet += indentString + `.timeout(${options.requestTimeout})\n`;
   }
   if (options.followRedirect === false) {
     snippet += indentString + '.followRedirect(false)\n';
   }
-
-  snippet += indentString + '.end(function (res) { \n';
+  if (options.ES6_enabled) {
+    snippet += indentString + '.end((res) => { \n';
+  }
+  else {
+    snippet += indentString + '.end(function (res) { \n';
+  }
   snippet += indentString.repeat(2) + 'if (res.error) throw new Error(res.error); \n';
   snippet += indentString.repeat(2) + 'console.log(res.raw_body);\n';
   snippet += indentString + '});\n';
@@ -137,6 +153,13 @@ function getOptions () {
       type: 'boolean',
       default: false,
       description: 'Remove white space and additional lines that may affect the server\'s response'
+    },
+    {
+      name: 'Enable ES6 features',
+      id: 'ES6_enabled',
+      type: 'boolean',
+      default: false,
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }
   ];
 }
@@ -150,6 +173,7 @@ function getOptions () {
  * @param {String} options.indentCount - number of spaces or tabs for indentation.
  * @param {Boolean} options.followRedirect - whether to enable followredirect
  * @param {Boolean} options.trimRequestBody - whether to trim fields in request body or not
+ * @param {Boolean} options.ES6_enabled - whether to generate snippet with ES6 features
  * @param {Number} options.requestTimeout : time in milli-seconds after which request will bail out
  * @param {Function} callback - callback function with parameters (error, snippet)
  */

--- a/codegens/nodejs-unirest/test/newman/newman.test.js
+++ b/codegens/nodejs-unirest/test/newman/newman.test.js
@@ -11,4 +11,16 @@ describe('Convert for different types of request', function () {
     };
 
   runNewmanTest(convert, options, testConfig);
+
+  describe('Convert for request incorporating ES6 features', function () {
+    var options = {indentCount: 2, indentType: 'Space', ES6_enabled: true},
+      testConfig = {
+        compileScript: null,
+        runScript: 'node run.js',
+        fileName: 'run.js',
+        headerSnippet: '/* eslint-disable */\n'
+      };
+
+    runNewmanTest(convert, options, testConfig);
+  });
 });

--- a/codegens/nodejs-unirest/test/unit/snippet.test.js
+++ b/codegens/nodejs-unirest/test/unit/snippet.test.js
@@ -48,6 +48,24 @@ describe('nodejs unirest convert function', function () {
       });
     });
 
+    it('should return snippet with ES6 features', function () {
+      request = new sdk.Request(mainCollection.item[0].request);
+      options = {
+        ES6_enabled: true
+      };
+      convert(request, options, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+          return;
+        }
+        expect(snippet).to.be.a('string');
+        snippetArray = snippet.split('\n');
+        expect(snippetArray[0]).to.equal('const unirest = require(\'unirest\');');
+        expect(snippetArray).to.include(`const req = unirest('${mainCollection.item[0].request.method}', ` +
+        `'${mainCollection.item[0].request.url.raw}')`);
+      });
+    });
+
     it('should return snippet with followRedirect function having ' +
         'parameter false for no follow redirect', function () {
       request = new sdk.Request(mainCollection.item[0].request);

--- a/codegens/nodejs-unirest/test/unit/snippet.test.js
+++ b/codegens/nodejs-unirest/test/unit/snippet.test.js
@@ -63,6 +63,7 @@ describe('nodejs unirest convert function', function () {
         expect(snippetArray[0]).to.equal('const unirest = require(\'unirest\');');
         expect(snippetArray).to.include(`const req = unirest('${mainCollection.item[0].request.method}', ` +
         `'${mainCollection.item[0].request.url.raw}')`);
+        expect(snippetArray).to.include('  .end((res) => { ');
       });
     });
 

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -60,6 +60,12 @@ const expectedOptions = {
       type: 'boolean',
       default: false,
       description: 'Display the requested data without showing the cURL progress meter or error messages'
+    },
+    ES6_enabled:{
+      name: 'Enable ES6 features',
+      type: 'boolean',
+      default: false,
+      description: 'Modifies code snippet to incorporate ES6 (EcmaScript) features'
     }
   },
   // Standard array of ids that should be used for options ids. Any new option should be updated here.
@@ -75,7 +81,8 @@ const expectedOptions = {
     'followRedirect',
     'lineContinuationCharacter',
     'protocol',
-    'useMimeType'
+    'useMimeType',
+    'ES6_enabled'
   ],
   CODEGEN_ABS_PATH = `./codegens/${codegen}`;
 describe('Code-gen repository ' + codegen, function () {


### PR DESCRIPTION
 **What this PR does**
It allows the user to generate the code snippet for NodeJS Unirest in the ES6 format.
This is in response to issue #115  requested by one of the users.

**Changes you made**

- Registered a new parameter ES6_enabled in **`options()`** which allows the user to toggle between whether codegen generates snippet with ES6 features or not.

- By default ES6_enabled is set to `false`

- Also added the newly created option parameter in **`structure.test.js`** file to register it as a valid option id.

- Added unit tests to verify the generated snippets in **snippet.test.js**

- Added a new mocha test suite to verify that the generated snippet is runnable in **newman.test.js.**

- Updated the **readme.md** file with new option parameter.

**Screenshot/ CodeSnippet**
Not required

**Test Configuration**:

- Added a unit test to check the snippet generated

- Added a new block of mocha test inside the main suite to verify that the snippet produced is runnable.

**Follow up**
Not required

*Thanks for contributing!* ❤️