### PR TITLE
Fix Python request multipart/form-data

### DIFF
--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -103,6 +103,10 @@ self = module.exports = {
 
     identity = options.indentType === 'Tab' ? '\t' : ' ';
     indentation = identity.repeat(options.indentCount);
+
+    if (request.body && request.body.mode === 'formdata') {
+      snippet += 'from requests_toolbelt import MultipartEncoder\n';
+    }
     snippet += 'import requests\n\n';
     snippet += `url = "${sanitize(request.url.toString(), 'url')}"\n\n`;
 

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -66,7 +66,8 @@ module.exports = function (request, indentation, bodyTrim) {
           bodyFileMap = _.map(_.filter(enabledBodyList, {'type': 'file'}), function (value) {
             return `${indentation}('${value.key}', open('${sanitize(value.src, request.body.mode, bodyTrim)}','rb'))`;
           });
-          requestBody = `payload = {${bodyDataMap.join(',\n')}}\nfiles = [\n${bodyFileMap.join(',\n')}\n]\n`;
+          requestBody = `payload = MultipartEncoder(\nfields={${bodyDataMap.join(',\n')}})\n` +
+           `files = [\n${bodyFileMap.join(',\n')}\n]\n`;
         }
         else {
           requestBody = 'payload = {}\nfiles = {}\n';


### PR DESCRIPTION
Currently, if you want to send form-data without any files, it does not work properly with `python-requests`. After a discussion with the developer of `python-requests-toolbelt`, @Marti2203 and I believe that using the aforementioned library would make things easier.