### PR TITLE
Fixed a bug which caused snippets generation to fail for form data params with no type key present

### DIFF
--- a/codegens/js-jquery/lib/js-jquery.js
+++ b/codegens/js-jquery/lib/js-jquery.js
@@ -51,14 +51,15 @@ function createForm (request, trimRequestBody) {
   enabledFormList = _.reject(request.body[request.body.mode], 'disabled');
   if (!_.isEmpty(enabledFormList)) {
     formMap = _.map(enabledFormList, function (value) {
-      if (value.type === 'text') {
-        return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", "` +
-                    `${sanitize(value.value, request.body.mode, trimRequestBody)}");`);
+      if (value.type === 'file') {
+        var pathArray = value.src.split(path.sep),
+          fileName = pathArray[pathArray.length - 1];
+        return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", fileInput.files[0], ` +
+          `"${sanitize(fileName, request.body.mode, trimRequestBody)}");`);
       }
-      var pathArray = value.src.split(path.sep),
-        fileName = pathArray[pathArray.length - 1];
-      return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", fileInput.files[0], ` +
-                    `"${sanitize(fileName, request.body.mode, trimRequestBody)}");`);
+      return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", "` +
+        `${sanitize(value.value, request.body.mode, trimRequestBody)}");`);
+
     });
     form += `${formMap.join('\n')}\n\n`;
   }
@@ -170,6 +171,7 @@ self = module.exports = {
       });
       jQueryCode = createForm(request.toJSON(), options.trimRequestBody);
     }
+    console.log(jQueryCode);
     jQueryCode += 'var settings = {\n';
     jQueryCode += `${indent}"url": "${sanitize(request.url.toString(), 'url')}",\n`;
     jQueryCode += `${indent}"method": "${request.method}",\n`;

--- a/codegens/js-jquery/lib/js-jquery.js
+++ b/codegens/js-jquery/lib/js-jquery.js
@@ -171,7 +171,6 @@ self = module.exports = {
       });
       jQueryCode = createForm(request.toJSON(), options.trimRequestBody);
     }
-    console.log(jQueryCode);
     jQueryCode += 'var settings = {\n';
     jQueryCode += `${indent}"url": "${sanitize(request.url.toString(), 'url')}",\n`;
     jQueryCode += `${indent}"method": "${request.method}",\n`;

--- a/codegens/js-jquery/test/unit/converter.test.js
+++ b/codegens/js-jquery/test/unit/converter.test.js
@@ -268,4 +268,36 @@ describe('jQuery converter', function () {
       expect(snippet).to.not.include('"sample_key": "value2"');
     });
   });
+
+  it('should generate snippet for form data params with no type key present', function () {
+    var request = new sdk.Request({
+      method: 'POST',
+      header: [],
+      url: {
+        raw: 'https://postman-echo.com/post',
+        protocol: 'https',
+        host: [
+          'postman-echo',
+          'com'
+        ],
+        path: [
+          'post'
+        ]
+      },
+      body: {
+        mode: 'formdata',
+        formdata: [
+          {
+            key: 'sample_key',
+            value: 'sample_value'
+          }
+        ]
+      }
+    });
+    convert(request, {}, function (error, snippet) {
+      expect(error).to.be.null;
+      expect(snippet).to.be.a('string');
+      expect(snippet).to.include('form.append("sample_key", "sample_value")');
+    });
+  });
 });

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -45,25 +45,25 @@ function parseFormData (body, trim) {
   var bodySnippet = '$multipartContent = [System.Net.Http.MultipartFormDataContent]::new()\n';
   _.forEach(body, function (data) {
     if (!data.disabled) {
-      if (data.type === 'text') {
+      if (data.type === 'file') {
+        var pathArray = data.src.split(path.sep),
+          fileName = pathArray[pathArray.length - 1];
+        bodySnippet += `$multipartFile = '${data.src}'\n` +
+        '$FileStream = [System.IO.FileStream]::new($multipartFile, [System.IO.FileMode]::Open)\n' +
+        '$fileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new("form-data")\n' +
+        `$fileHeader.Name = "${sanitize(data.key)}"\n` +
+        `$fileHeader.FileName = "${sanitize(fileName, trim)}"\n` +
+        '$fileContent = [System.Net.Http.StreamContent]::new($FileStream)\n' +
+        '$fileContent.Headers.ContentDisposition = $fileHeader\n' +
+        '$multipartContent.Add($fileContent)\n\n';
+      }
+      else {
         bodySnippet += '$stringHeader = ' +
           '[System.Net.Http.Headers.ContentDispositionHeaderValue]::new("form-data")\n' +
           `$stringHeader.Name = "${sanitize(data.key, trim)}"\n` +
           `$StringContent = [System.Net.Http.StringContent]::new("${sanitize(data.value, trim)}")\n` +
           '$StringContent.Headers.ContentDisposition = $stringHeader\n' +
           '$multipartContent.Add($stringContent)\n\n';
-      }
-      else {
-        var pathArray = data.src.split(path.sep),
-          fileName = pathArray[pathArray.length - 1];
-        bodySnippet += `$multipartFile = '${data.src}'\n` +
-          '$FileStream = [System.IO.FileStream]::new($multipartFile, [System.IO.FileMode]::Open)\n' +
-          '$fileHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new("form-data")\n' +
-          `$fileHeader.Name = "${sanitize(data.key)}"\n` +
-          `$fileHeader.FileName = "${sanitize(fileName, trim)}"\n` +
-          '$fileContent = [System.Net.Http.StreamContent]::new($FileStream)\n' +
-          '$fileContent.Headers.ContentDisposition = $fileHeader\n' +
-          '$multipartContent.Add($fileContent)\n\n';
       }
     }
   });

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -458,6 +458,41 @@ describe('Powershell-restmethod converter', function () {
         expect(snippet).to.include("'https://postman-echo.com/get?query1=b''b&query2=c\"c'");
       });
     });
+
+    it('should generate snippet for form data params with no type key present', function () {
+      var request = new sdk.Request({
+        method: 'POST',
+        header: [],
+        url: {
+          raw: 'https://postman-echo.com/post',
+          protocol: 'https',
+          host: [
+            'postman-echo',
+            'com'
+          ],
+          path: [
+            'post'
+          ]
+        },
+        body: {
+          mode: 'formdata',
+          formdata: [
+            {
+              key: 'sample_key',
+              value: 'sample_value'
+            }
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        expect(error).to.be.null;
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('$stringHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]' +
+        '::new("form-data")');
+        expect(snippet).to.include('$stringHeader.Name = "sample_key"');
+        expect(snippet).to.include('$StringContent = [System.Net.Http.StringContent]::new("sample_value")');
+      });
+    });
   });
 
   describe('getOptions function', function () {


### PR DESCRIPTION
**Affected codegens**
- js-jquery
- powershell-restmethod

**RCA**
- The code generator throws the following error:
```
TypeError: Cannot read property 'split' of undefined
```
- We use src.split to get the filename from the path of the file stored in formParam.src field
- This problem is seen in older collection versions, where the type parameter is not present in form-data parameters. The way we generate code for form params is as following:

 ```
if (value.type === 'text') {
        return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", "` +
                    `${sanitize(value.value, request.body.mode, trimRequestBody)}");`);
      }
      var pathArray = value.src.split(path.sep),
        fileName = pathArray[pathArray.length - 1];
      return (`form.append("${sanitize(value.key, request.body.mode, trimRequestBody)}", fileInput.files[0], ` +
                    `"${sanitize(fileName, request.body.mode, trimRequestBody)}");`);
    });
  form += `${formMap.join('\n')}\n\n`;
}
```
- The form parameter under consideration is of type text, but due to the older collection version, the parameter is missing a type property. This property is present in v2.1 of collections and is set to text and file for text and file parameters respectively.
- The form parameter does not have a value.type property and hence the code assumes that the current form parameter is a type=file parameter. Hence we try to get the file name from the src field which has the path of the file stored in it. This throws an error as value.src is undefined


**Why are the other code generators that access the value.src for getting file name not failing?**
- Well, in all the other code generators, we check for the type=file before, and if the type is not a file, default to it being a text parameter. The code for the same is shown below:
```
if (data.type === 'file') {
  var pathArray = data.src.split(path.sep),
   fileName = pathArray[pathArray.length - 1];
  bodySnippet += `formdata.append("${sanitize(data.key, trim)}", fileInput.files[0], "${fileName}");\n`;
}
else {
  bodySnippet += `formdata.append("${sanitize(data.key, trim)}", "${sanitize(data.value, trim)}");\n`;
}
```
- Thus, we check for param.src if and only if type is defined as file. For all the other cases, consider it as a text parameter and just put the text as provided by the value field from form-data param in the code generated