### PR TITLE
Removes utf8 encoding from generated snippet (python-requests)

### DIFF
--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -170,7 +170,7 @@ self = module.exports = {
     snippet += !options.followRedirect ? ', allow_redirects = False' : '';
     snippet += options.requestTimeout !== 0 ? `, timeout=${options.requestTimeout}` : '';
     snippet += ')\n\n';
-    snippet += 'print(response.text.encode(\'utf8\'))\n';
+    snippet += 'print(response.text)\n';
 
     callback(null, snippet);
   }


### PR DESCRIPTION
Fixes #249

RCA
This issue was due to different versions of python. In python 2.x, byte strings are printed without any prefix/suffix unlike the case in python 3.x where resulting byte code is inside `b' string here '`.

Solution
Removing encoding solves the above issue.

This PR adds the following changes:
 - removes .encode(utf8) from print statement in generated snippet