### PR TITLE
Go: Use Multiline Strings for Raw Bodies

### DIFF
--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -1,5 +1,6 @@
 var _ = require('./lodash'),
   sanitize = require('./util').sanitize,
+  sanitizeMultiline = require('./util').sanitizeMultiline,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
   isFile = false,
@@ -13,7 +14,7 @@ var _ = require('./lodash'),
  */
 function parseRawBody (body, trim) {
   var bodySnippet;
-  bodySnippet = `payload := strings.NewReader("${sanitize(body.toString(), trim)}")`;
+  bodySnippet = `payload := strings.NewReader(\`${sanitizeMultiline(body.toString(), trim)}\`)`;
   return bodySnippet;
 }
 

--- a/codegens/golang/lib/util.js
+++ b/codegens/golang/lib/util.js
@@ -17,6 +17,23 @@ module.exports = {
   },
 
   /**
+     * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
+     * and trim input if required
+     *
+     * @param {String} inputString
+     * @param {Boolean} [trim] - indicates whether to trim string or not
+     * @returns {String}
+     */
+  sanitizeMultiline: function (inputString, trim) {
+    if (typeof inputString !== 'string') {
+      return '';
+    }
+    inputString = inputString.replace(/`/g, '`+"`"+`');
+    return trim ? inputString.trim() : inputString;
+
+  },
+
+  /**
     * sanitizes input options
     *
     * @param {Object} options - Options provided by the user


### PR DESCRIPTION
This is random, but when looking up documentation for the [CyberSource REST API](https://developer.cybersource.com/api-reference-assets/index.html#payments_payments_process-a-payment) I randomly came across [these Postman docs](https://documenter.getpostman.com/view/2960117/S17m1riA?version=latest#6365de64-d3f7-45ff-bb98-1a5efe4df79e).  (How do such docs even come into being?...)

When I changed the language to `Go - Native`, what do I behold?

```go
// ...
  payload := strings.NewReader("{
\n  	\"clientReferenceInformation\": {
\n  		\"code\": \"test_payment\"
\n  	},
\n  	\"processingInformation\": {
\n  		\"commerceIndicator\": \"internet\"
\n  	},						
\n  	\"orderInformation\": {
\n  		\"billTo\": {	
\n  			\"firstName\": \"John\",
\n  			\"lastName\": \"Doe\",
\n  			\"address1\": \"1 Market St\",
\n  			\"postalCode\": \"94105\",
\n  			\"locality\": \"san francisco\",
\n  			\"administrativeArea\": \"CA\",
\n  			\"country\": \"US\",
\n  			\"phoneNumber\": \"4158880000\",
\n  			\"company\": \"Visa\",
\n  			\"email\": \"test@cybs.com\"
\n  		},
\n  		\"amountDetails\": {
\n  			\"totalAmount\": \"102.21\",
\n  			\"currency\": \"USD\"
\n  		}
\n  	},
\n  	\"paymentInformation\": {
\n  		\"card\": {
\n  			\"expirationYear\": \"2031\",
\n  			\"number\": \"4111111111111111\",
\n  			\"securityCode\": \"123\",
\n  			\"expirationMonth\": \"12\"
\n  		}
\n  	}
\n  }")
// ...
```

Good heavens!  This is why we have multiline literal strings in Go!

This PR should hopefully handle this travesty.  Unfortunately my node-fu is not amazing, so even after an `npm ci` I couldn't actually get `npm test` to work without complaining about missing the `newman` module...so I gave up on that.  I may not have all of my ducks in a row but this PR gets you most of the way there.

The new intended output is:
```go
payload := strings.NewReader(`{
	"clientReferenceInformation": {
		"code": "test_payment"
	},
	"processingInformation": {
		"commerceIndicator": "internet"
	},						
	"orderInformation": {
		"billTo": {	
			"firstName": "John",
			"lastName": "Doe",
			"address1": "1 Market St",
			"postalCode": "94105",
			"locality": "san francisco",
			"administrativeArea": "CA",
			"country": "US",
			"phoneNumber": "4158880000",
			"company": "Visa",
			"email": "test@cybs.com"
		},
		"amountDetails": {
			"totalAmount": "102.21",
			"currency": "USD"
		}
	},
	"paymentInformation": {
		"card": {
			"expirationYear": "2031",
			"number": "4111111111111111",
			"securityCode": "123",
			"expirationMonth": "12"
		}
	}
`)
```