### PR TITLE
Adds ContentType to python snippets for multipart/formdata

### DIFF
--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -139,7 +139,7 @@ module.exports = function (request, indentation, bodyTrim) {
           bodyFileMap = _.map(_.filter(enabledBodyList, {'type': 'file'}), function (value) {
             var filesrc = value.src,
               filetype = filesrc.split('.')[filesrc.split('.').length - 1];
-            return `${indentation}('${value.key}',('${filesrc}'` +
+            return `${indentation}('${value.key}',('${filesrc.split('/')[filesrc.split('/').length - 1]}'` +
                     `,open('${sanitize(filesrc, request.body.mode, bodyTrim)}','rb'),` +
                     `'${contentTypeHeaderMap[filetype]}'))`;
           });

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -138,10 +138,15 @@ module.exports = function (request, indentation, bodyTrim) {
           });
           bodyFileMap = _.map(_.filter(enabledBodyList, {'type': 'file'}), function (value) {
             var filesrc = value.src,
-              filetype = filesrc.split('.')[filesrc.split('.').length - 1];
+              fileType = filesrc.split('.')[filesrc.split('.').length - 1],
+              contentType = contentTypeHeaderMap[fileType];
+
+            if (!contentType) {
+              contentType = 'application/octet-stream';
+            }
             return `${indentation}('${value.key}',('${filesrc.split('/')[filesrc.split('/').length - 1]}'` +
                     `,open('${sanitize(filesrc, request.body.mode, bodyTrim)}','rb'),` +
-                    `'${contentTypeHeaderMap[filetype]}'))`;
+                    `'${contentType}'))`;
           });
           requestBody = `payload = {${bodyDataMap.join(',\n')}}\nfiles = [\n${bodyFileMap.join(',\n')}\n]\n`;
         }

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -1,5 +1,78 @@
 var _ = require('../lodash'),
-  sanitize = require('./sanitize').sanitize;
+  sanitize = require('./sanitize').sanitize,
+  contentTypeHeaderMap = {
+    'aac': 'audio/aac',
+    'abw': 'application/x-abiword',
+    'arc': 'application/x-freearc',
+    'avi': 'video/x-msvideo',
+    'azw': 'application/vnd.amazon.ebook',
+    'bin': 'application/octet-stream',
+    'bmp': 'image/bmp',
+    'bz': 'application/x-bzip',
+    'bz2': 'application/x-bzip2',
+    'csh': 'application/x-csh',
+    'css': 'text/css',
+    'csv': 'text/csv',
+    'doc': 'application/msword',
+    'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'eot': 'application/vnd.ms-fontobject',
+    'epub': 'application/epub+zip',
+    'gif': 'image/gif',
+    'htm': 'text/html',
+    'html': 'text/html',
+    'ico': 'image/vnd.microsoft.icon',
+    'ics': 'text/calendar',
+    'jar': 'application/java-archive',
+    'jpeg': 'image/jpeg',
+    'jpg': 'image/jpeg',
+    'js': 'text/javascript',
+    'json': 'application/json',
+    'jsonld': 'application/ld+json',
+    'mid': 'audip/midi',
+    'midi': 'audio/midi',
+    'mjs': 'text/javascript',
+    'mp3': 'audio/mpeg',
+    'mpeg': 'video/mpeg',
+    'mpkg': 'application/vnd.apple.installer+xml',
+    'odp': 'application/vnd.oasis.opendocument.presentation',
+    'ods': 'application/vnd.oasis.opendocument.spreadsheet',
+    'odt': 'application/vnd.oasis.opendocument.text',
+    'oga': 'audio/ogg',
+    'ogv': 'video/ogg',
+    'ogx': 'application/ogg',
+    'otf': 'font/otf',
+    'png': 'image/png',
+    'pdf': 'application/pdf',
+    'ppt': 'application/vnd.ms-powerpoint',
+    'pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'rar': 'application/x-rar-compressed',
+    'rtf': 'application/rtf',
+    'sh': 'application/x-sh',
+    'svg': 'image/svg+xml',
+    'swf': 'application/x-shockwave-flash',
+    'tar': 'application/x-tar',
+    'tif': 'image/tiff',
+    'tiff': 'image/tiff',
+    'ts': 'video/mp2t',
+    'ttf': 'font/ttf',
+    'txt': 'text/plain',
+    'vsd': 'application/vnd.visio',
+    'wav': 'audio/wav',
+    'weba': 'audio/webm',
+    'webm': 'video/webm',
+    'webp': 'image/webp',
+    'woff': 'font/woff',
+    'woff2': 'font/woff2',
+    'xhtml': 'application/xhtml+xml',
+    'xls': 'application/vnd.ms-excel',
+    'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'xml': 'text/xml',
+    'xul': 'application/vnd.mozilla.xul+xml',
+    'zip': 'application/zip',
+    '3gp': 'video/3gpp',
+    '7z': 'application/x-7z-compressed',
+    '7-zip': 'application/x-7z-compressed'
+  };
 
 /**
  * Used to parse the body of the postman SDK-request and return in the desired format
@@ -64,7 +137,11 @@ module.exports = function (request, indentation, bodyTrim) {
                             `'${sanitize(value.value, request.body.mode, bodyTrim)}'`);
           });
           bodyFileMap = _.map(_.filter(enabledBodyList, {'type': 'file'}), function (value) {
-            return `${indentation}('${value.key}', open('${sanitize(value.src, request.body.mode, bodyTrim)}','rb'))`;
+            var filesrc = value.src,
+              filetype = filesrc.split('.')[filesrc.split('.').length - 1];
+            return `${indentation}('${value.key}',('${filesrc}'` +
+                    `,open('${sanitize(filesrc, request.body.mode, bodyTrim)}','rb'),` +
+                    `'${contentTypeHeaderMap[filetype]}'))`;
           });
           requestBody = `payload = {${bodyDataMap.join(',\n')}}\nfiles = [\n${bodyFileMap.join(',\n')}\n]\n`;
         }

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -106,9 +106,9 @@ describe('Python- Requests converter', function () {
         expect.fail(null, null, error);
       }
       expect(snippet).to.be.a('string');
-      expect(snippet).to.include('(\'no file\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
-      expect(snippet).to.include('(\'no src\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
-      expect(snippet).to.include('(\'invalid src\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      expect(snippet).to.include('(\'no file\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      expect(snippet).to.include('(\'no src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      expect(snippet).to.include('(\'invalid src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
     });
   });
 

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -106,9 +106,12 @@ describe('Python- Requests converter', function () {
         expect.fail(null, null, error);
       }
       expect(snippet).to.be.a('string');
-      expect(snippet).to.include('(\'no file\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
-      expect(snippet).to.include('(\'no src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
-      expect(snippet).to.include('(\'invalid src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      // eslint-disable-next-line max-len
+      expect(snippet).to.include('(\'no file\',(\'file\',open(\'/path/to/file\',\'rb\'),\'application/octet-stream\'))');
+      // eslint-disable-next-line max-len
+      expect(snippet).to.include('(\'no src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'application/octet-stream\'))');
+      // eslint-disable-next-line max-len
+      expect(snippet).to.include('(\'invalid src\',(\'file\',open(\'/path/to/file\',\'rb\'),\'application/octet-stream\'))');
     });
   });
 

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -106,9 +106,9 @@ describe('Python- Requests converter', function () {
         expect.fail(null, null, error);
       }
       expect(snippet).to.be.a('string');
-      expect(snippet).to.include('(\'no file\', open(\'/path/to/file\',\'rb\'))');
-      expect(snippet).to.include('(\'no src\', open(\'/path/to/file\',\'rb\'))');
-      expect(snippet).to.include('(\'invalid src\', open(\'/path/to/file\',\'rb\'))');
+      expect(snippet).to.include('(\'no file\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      expect(snippet).to.include('(\'no src\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
+      expect(snippet).to.include('(\'invalid src\',(\'/path/to/file\',open(\'/path/to/file\',\'rb\'),\'undefined\'))');
     });
   });
 


### PR DESCRIPTION
Fixes #247 
 - Adds ContentTypetoHeader map
 - Adds snipept for content type
 - Modifies test for `no file in formdata`