### PR TITLE
Adds snippet to check err before using res in GoNative

### DIFF
--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -280,10 +280,13 @@ self = module.exports = {
       codeSnippet += `${indent}req.Header.Set("Content-Type", writer.FormDataContentType())\n`;
     }
     responseSnippet = `${indent}res, err := client.Do(req)\n`;
+    responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
+    responseSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
     responseSnippet += `${indent}defer res.Body.Close()\n${indent}body, err := ioutil.ReadAll(res.Body)\n\n`;
     responseSnippet += `${indent}fmt.Println(string(body))\n}`;
 
     codeSnippet += responseSnippet;
+    console.log(codeSnippet);
     callback(null, codeSnippet);
   },
   getOptions: function () {

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -282,12 +282,13 @@ self = module.exports = {
     responseSnippet = `${indent}res, err := client.Do(req)\n`;
     responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
     responseSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
-    responseSnippet += `${indent}defer res.Body.Close()\n${indent}body, err := ioutil.ReadAll(res.Body)\n\n`;
+    responseSnippet += `${indent}defer res.Body.Close()\n\n${indent}body, err := ioutil.ReadAll(res.Body)\n`;
     responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
     responseSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
     responseSnippet += `${indent}fmt.Println(string(body))\n}`;
 
     codeSnippet += responseSnippet;
+    console.log(codeSnippet);
     callback(null, codeSnippet);
   },
   getOptions: function () {

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -257,7 +257,8 @@ self = module.exports = {
     else {
       codeSnippet += `${indent}req, err := http.NewRequest(method, url, nil)\n\n`;
     }
-    codeSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n${indent}}\n`;
+    codeSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
+    codeSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
     if (request.body && !request.headers.has('Content-Type')) {
       if (request.body.mode === 'file') {
         request.addHeader({

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -288,7 +288,6 @@ self = module.exports = {
     responseSnippet += `${indent}fmt.Println(string(body))\n}`;
 
     codeSnippet += responseSnippet;
-    console.log(codeSnippet);
     callback(null, codeSnippet);
   },
   getOptions: function () {

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -78,8 +78,8 @@ function parseFormData (body, trim, indent) {
          errFile${index + 1} := writer.CreateFormFile("${sanitize(data.key, trim)}",` +
                         `filepath.Base("${data.src}"))\n`;
         bodySnippet += `${indent}_, errFile${index + 1} = io.Copy(part${index + 1}, file)\n`;
-        bodySnippet += `${indent}if errFile${index + 1} != nil {` + 
-          `\n${indent.repeat(2)}fmt.Println(errFile${index + 1})\n` + 
+        bodySnippet += `${indent}if errFile${index + 1} != nil {` +
+          `\n${indent.repeat(2)}fmt.Println(errFile${index + 1})\n` +
           `${indent.repeat(2)}return\n${indent}}\n`;
       }
       else {

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -283,10 +283,11 @@ self = module.exports = {
     responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
     responseSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
     responseSnippet += `${indent}defer res.Body.Close()\n${indent}body, err := ioutil.ReadAll(res.Body)\n\n`;
+    responseSnippet += `${indent}if err != nil {\n${indent.repeat(2)}fmt.Println(err)\n`;
+    responseSnippet += `${indent.repeat(2)}return\n${indent}}\n`;
     responseSnippet += `${indent}fmt.Println(string(body))\n}`;
 
     codeSnippet += responseSnippet;
-    console.log(codeSnippet);
     callback(null, codeSnippet);
   },
   getOptions: function () {

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -78,8 +78,9 @@ function parseFormData (body, trim, indent) {
          errFile${index + 1} := writer.CreateFormFile("${sanitize(data.key, trim)}",` +
                         `filepath.Base("${data.src}"))\n`;
         bodySnippet += `${indent}_, errFile${index + 1} = io.Copy(part${index + 1}, file)\n`;
-        bodySnippet += `${indent}if errFile${index + 1} !=nil {
-          \n${indent.repeat(2)}fmt.Println(errFile${index + 1})\n${indent}}\n`;
+        bodySnippet += `${indent}if errFile${index + 1} != nil {` + 
+          `\n${indent.repeat(2)}fmt.Println(errFile${index + 1})\n` + 
+          `${indent.repeat(2)}return\n${indent}}\n`;
       }
       else {
         bodySnippet += `${indent}_ = writer.WriteField("${sanitize(data.key, trim)}",`;
@@ -88,7 +89,8 @@ function parseFormData (body, trim, indent) {
     }
   });
   bodySnippet += `${indent}err := writer.Close()\n${indent}if err != nil ` +
-  `{\n${indent.repeat(2)}fmt.Println(err)\n${indent}}\n`;
+  `{\n${indent.repeat(2)}fmt.Println(err)\n` +
+  `${indent.repeat(2)}return\n${indent}}\n`;
   return bodySnippet;
 }
 

--- a/codegens/golang/test/unit/convert.test.js
+++ b/codegens/golang/test/unit/convert.test.js
@@ -165,5 +165,54 @@ describe('Golang convert function', function () {
         expect(snippet).to.include('writer.CreateFormFile("invalid src",filepath.Base("/path/to/file"))');
       });
     });
+
+    it('should add error handling code everytime an error is possible', function () {
+      var requests = [];
+      requests.push(new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'foo',
+            'value': 'bar'
+          }
+        ],
+        'url': {
+          'raw': 'https://example.com',
+          'protocol': 'http',
+          'host': [
+            'example',
+            'com'
+          ]
+        }
+      }));
+      requests.push(new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'body': {
+          'mode': 'raw',
+          'raw': 'hello world'
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/post',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      }));
+      requests.forEach(function (request) {
+        convert(request, {}, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet.match('err := ').length).to.be.equal(snippet.match('if err != nil {').length);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/postmanlabs/postman-app-support/issues/8318 partially
The err due to absence of `err` check is caused by go vet(kind of linting for go), which forces strict formatting, this includes checking for err being nil or not  if we have assigned some value to `err`. 
So basically if anyone uses go vet then `err` checking is mandatory if it has been assigned:
`if err!=nil {
    //do something
 }
`

 - adds err check after client.Do(req)
 - adds println and return statement inside err condition body