### PR TITLE
Fixes issue with semicolon in form data (CURL)

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -141,16 +141,11 @@ self = module.exports = {
               if (!(data.disabled)) {
                 if (data.type === 'file') {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += data.value.match(/[,;]/g) ?
-                    ` '${sanitize(data.key, trim)}=@"${sanitize(data.src, trim, true, true)}"'` :
-                    ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
+                  snippet += ` '${sanitize(data.key, trim)}=@"${sanitize(data.src, trim, true, true)}"'`;
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += data.value.match(/[,;]/g) ?
-                    // eslint-disable-next-line max-len
-                    ` '${sanitize(data.key, trim)}="${sanitize(data.value, trim, true, true)}"'` :
-                    ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
+                  snippet += ` '${sanitize(data.key, trim)}="${sanitize(data.value, trim, true, true)}"'`;
                 }
               }
             });
@@ -164,7 +159,7 @@ self = module.exports = {
         }
       }
     }
-    console.log(snippet);
+
     callback(null, snippet);
   },
   getOptions: function () {

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -141,11 +141,16 @@ self = module.exports = {
               if (!(data.disabled)) {
                 if (data.type === 'file') {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
+                  snippet += data.value.match(/[,;]/g) ?
+                    ` '${sanitize(data.key, trim)}=@"${sanitize(data.src, trim, true, true)}"'` :
+                    ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
+                  snippet += data.value.match(/[,;]/g) ?
+                    // eslint-disable-next-line max-len
+                    ` '${sanitize(data.key, trim)}="${sanitize(data.value, trim, true, true)}"'` :
+                    ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
                 }
               }
             });
@@ -159,6 +164,7 @@ self = module.exports = {
         }
       }
     }
+    console.log(snippet);
     callback(null, snippet);
   },
   getOptions: function () {

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -1,20 +1,32 @@
 module.exports = {
   /**
-     * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
+     * sanitizes input string by handling escape characters eg: converts '''' to '\'\'', (" to \"  and \ to \\ )
      * and trim input if required
      *
      * @param {String} inputString
      * @param {Boolean} [trim] - indicates whether to trim string or not
+     * @param {Boolean} [doubleQuotes] - indicates whether to escape double quotes(") and backslash(\\)
+     * @param {Boolean} [backSlash] - indicates whether to escape backslash(\\)
      * @returns {String}
      */
-  sanitize: function (inputString, trim) {
+  sanitize: function (inputString, trim, doubleQuotes, backSlash) {
     if (typeof inputString !== 'string') {
       return '';
     }
+
+    if (backSlash) {
+      inputString = inputString.replace('\\', '\\\\');
+    }
+
+    if (doubleQuotes) {
+      inputString = inputString.replace('"', '\\"');
+    }
+
     // for curl escaping of single quotes inside single quotes involves changing of ' to '\''
     inputString = inputString.replace(/'/g, "'\\''"); // eslint-disable-line quotes
     return trim ? inputString.trim() : inputString;
   },
+
   form: function (option, format) {
     if (format) {
       switch (option) {

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -15,11 +15,11 @@ module.exports = {
     }
 
     if (backSlash) {
-      inputString = inputString.replace('\\', '\\\\');
+      inputString = inputString.replace(/\\/g, '\\\\');
     }
 
     if (doubleQuotes) {
-      inputString = inputString.replace('"', '\\"');
+      inputString = inputString.replace(/"/g, '\\"');
     }
 
     // for curl escaping of single quotes inside single quotes involves changing of ' to '\''

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -250,9 +250,9 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('no file=@/path/to/file');
-        expect(snippet).to.include('no src=@/path/to/file');
-        expect(snippet).to.include('invalid src=@/path/to/file');
+        expect(snippet).to.include('no file=@"/path/to/file"');
+        expect(snippet).to.include('no src=@"/path/to/file"');
+        expect(snippet).to.include('invalid src=@"/path/to/file"');
       });
     });
 

--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -44,5 +44,18 @@ popd &>/dev/null;
 echo "Installing dependencies required for tests in codegens/csharp-restsharp"
 sudo apt-get install -y mono-complete
 
+echo "Installing curl v7.68"
+  sudo apt-get install -y libssl-dev autoconf libtool make
+  wget https://curl.haxx.se/download/curl-7.68.0.zip
+  unzip curl-7.68.0.zip
+  pushd ./curl-7.68.0 &>/dev/null
+  ./buildconf
+  ./configure --with-ssl
+  make
+  sudo make install
+  sudo cp /usr/local/bin/curl /usr/bin/curl
+  sudo ldconfig
+  popd &>/dev/null
+
 echo "Installing dependencies required for tests in codegens/shell-httpie"
 sudo apt-get install httpie


### PR DESCRIPTION
fixes #257 
Curl requires form data to be enclosed in double quotes if form data value contains semicolon or comma
![image](https://user-images.githubusercontent.com/41543649/83575934-37c65b80-a54e-11ea-8d26-73773f38a375.png)


This PR adds check for the above conditions and adds the following changes 

- adds check for semicolon and comma in form data
 - encloses form data value if semicolon/comma is present
 - Modifies sanitize function, adds follows
    - adds option to escape double quotes
    - adds option to escape back slash