### PR TITLE
Adding '\' before a valid PHP variable name solves #284

### DIFF
--- a/codegens/php-curl/lib/php-curl.js
+++ b/codegens/php-curl/lib/php-curl.js
@@ -110,6 +110,8 @@ self = module.exports = {
       // needs to be encoded
       finalUrl = encodeURI(finalUrl);
     }
+    // Adding '\' before a valid PHP variable name
+    finalUrl = finalUrl.replace(/\$([a-z]|[A-Z]|[_])/g, function(m){return '\\'+m});
     snippet = '<?php\n\n$curl = curl_init();\n\n';
     snippet += 'curl_setopt_array($curl, array(\n';
     snippet += `${indentation}CURLOPT_URL => "${sanitize(finalUrl, 'url')}",\n`;


### PR DESCRIPTION
## Solves #284

# Why my solution works :-

My solution is very simple and straight forward, I am just replacing the occurrence of a valid PHP URL with '**\\**' added at the begning. I have tested this code with various test cases and it is working flawlessly.
