### PR TITLE
Add sanitising of quotes in URLs(and paths)

### DIFF
--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -1,4 +1,4 @@
-module.exports = {
+var self = module.exports = {
   /**
      * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
      * and trim input if required
@@ -149,7 +149,7 @@ module.exports = {
       url += '#' + urlObject.hash;
     }
 
-    return url;
+    return self.sanitize(url);
   },
 
   /**

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -256,6 +256,19 @@ describe('curl convert function', function () {
       });
     });
 
+    it('should generate valid snippets for single/double quotes in URL', function () {
+      // url = https://a"b'c.com/'d/"e
+      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        // for curl escaping of single quotes inside single quotes involves changing of ' to '\''
+        // expect => 'https://a"b'\''c.com/'\''d/"e'
+        expect(snippet).to.include("'https://a\"b'\\''c.com/'\\''d/\"e'"); // eslint-disable-line quotes
+      });
+    });
+
     describe('getUrlStringfromUrlObject function', function () {
       var rawUrl, urlObject, outputUrlString;
 

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -40,7 +40,7 @@ function getUrlStringfromUrlObject (urlObject) {
     url += '#' + urlObject.hash;
   }
 
-  return url;
+  return sanitize(url);
 }
 
 /**

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -369,6 +369,19 @@ describe('java unirest convert function for test collection', function () {
         expect(snippet).to.include('.field("file", new File("/path/to/file"))');
       });
     });
+
+    it('should generate valid snippets for single/double quotes in URL', function () {
+      // url = https://a"b'c.com/'d/"e
+      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        // expect => Unirest.get("https://a\"b'c.com/'d/\"e")
+        expect(snippet).to.include('Unirest.get("https://a\\"b\'c.com/\'d/\\"e")');
+      });
+    });
+
   });
   describe('getUrlStringfromUrlObject function', function () {
     var rawUrl, urlObject, outputUrlString;

--- a/codegens/nodejs-native/lib/parseRequest.js
+++ b/codegens/nodejs-native/lib/parseRequest.js
@@ -209,7 +209,7 @@ function parsePath (request, indentString) {
     querySnippet = '';
 
   if (pathArray && pathArray.length) {
-    pathSnippet += sanitize(_.reduce(pathArray, function (accumalator, key) {
+    pathSnippet += (_.reduce(pathArray, function (accumalator, key) {
       if (key.length) {
         accumalator.push(`${sanitize(key)}`);
       }

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -272,4 +272,18 @@ describe('nodejs-native convert function', function () {
       expect(snippet).to.include(':action');
     });
   });
+
+  it('should generate valid snippet paths for single/double quotes in URL', function () {
+    // url = https://a"b'c.com/'d/"e
+    var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      // expect => 'hostname': 'a"b\'c.com'
+      expect(snippet).to.include("'hostname': 'a\"b\\'c.com'"); // eslint-disable-line quotes
+      // expect => 'path': '\'d/"e'
+      expect(snippet).to.include("'path': '/\\'d/\"e'"); // eslint-disable-line quotes
+    });
+  });
 });

--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -42,7 +42,7 @@ function getheaders (request, indentation) {
  * @returns {String} - Url path with query (no host)
  */
 function getUrlPathWithQuery (requestUrl) {
-  var path = requestUrl.getPath(),
+  var path = sanitize(requestUrl.getPath()),
     query = requestUrl.getQueryString({ ignoreDisabled: true }),
     urlPathWithQuery = '';
 
@@ -131,7 +131,7 @@ self = module.exports = {
 
     snippet += 'import http.client\n';
     snippet += 'import mimetypes\n';
-    snippet += `conn = http.client.HTTPSConnection("${request.url.host ? request.url.host.join('.') : ''}"`;
+    snippet += `conn = http.client.HTTPSConnection("${sanitize(request.url.host ? request.url.host.join('.') : '')}"`;
     snippet += request.url.port ? `, ${request.url.port}` : '';
     snippet += options.requestTimeout !== 0 ? `, timeout = ${options.requestTimeout})\n` : ')\n';
 

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -220,6 +220,20 @@ describe('Python-http.client converter', function () {
       });
     });
 
+    it('should generate valid snippets for single/double quotes in URL', function () {
+      // url = https://a"b'c.com/'d/"e
+      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        // expect => http.client.HTTPSConnection("a\"b'c.com"")
+        expect(snippet).to.include('http.client.HTTPSConnection("a\\"b\'c.com")');
+        // expect conn.request("GET", "/'d/\"e", payload, headers)
+        expect(snippet).to.include('conn.request("GET", "/\'d/\\"e", payload, headers)');
+      });
+    });
+
   });
 
   describe('parseBody function', function () {

--- a/codegens/swift/lib/util.js
+++ b/codegens/swift/lib/util.js
@@ -139,7 +139,7 @@ function getUrlStringfromUrlObject (urlObject) {
     url += '#' + urlObject.hash;
   }
 
-  return url;
+  return sanitize(url, 'url');
 }
 
 /**

--- a/codegens/swift/test/unit/convert.test.js
+++ b/codegens/swift/test/unit/convert.test.js
@@ -199,6 +199,18 @@ describe('Swift Converter', function () {
         expect(snippet).to.include('"key": "invalid src"');
       });
     });
+
+    it('should generate valid snippets for single/double quotes in URL', function () {
+      // url = https://a"b'c.com/'d/"e
+      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        // expect => URL(string: "https://a\"b'c.com/'d/\"e"
+        expect(snippet).to.include('URL(string: "https://a\\"b\'c.com/\'d/\\"e")');
+      });
+    });
   });
 
   describe('getUrlStringfromUrlObject function', function () {


### PR DESCRIPTION
Fixes https://github.com/postmanlabs/postman-app-support/issues/8674
Single/double quotes were not handled correctly in some of the languages.

Languages affected:
 - cURL
 - Java Unirest
 - NodeJS Native (path)
 - Python http.client
 - Swift