### PR TITLE
Replaces double quote to single quote for body params

### DIFF
--- a/codegens/nodejs-request/lib/parseRequest.js
+++ b/codegens/nodejs-request/lib/parseRequest.js
@@ -102,10 +102,10 @@ function parseBody (requestbody, indentString, trimBody, contentType) {
             return `body: JSON.stringify(${JSON.stringify(jsonBody)})\n`;
           }
           catch (error) {
-            return `body: ${JSON.stringify(requestbody[requestbody.mode])}\n`;
+            return `body: '${sanitize(requestbody[requestbody.mode])}'\n`;
           }
         }
-        return `body: ${JSON.stringify(requestbody[requestbody.mode])}\n`;
+        return `body: '${sanitize(requestbody[requestbody.mode])}'\n`;
       // eslint-disable-next-line no-case-declarations
       case 'graphql':
         let query = requestbody[requestbody.mode].query,


### PR DESCRIPTION
Previously the generated snippet with raw body had double quote wrapping. This pr changes it to single quote to have consistency in quotes throughout the generated snippet.
Changes:
 - removes json.stringify where not necessary
 - sanitize raw body 