### PR TITLE
Signal the semaphore on a fail case as well

### DIFF
--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -367,6 +367,7 @@ self = module.exports = {
     codeSnippet += '\nlet task = URLSession.shared.dataTask(with: request) { data, response, error in \n';
     codeSnippet += `${indent}guard let data = data else {\n`;
     codeSnippet += `${indent.repeat(2)}print(String(describing: error))\n`;
+    codeSnippet += `${indent.repeat(2)}semaphore.signal()`;
     codeSnippet += `${indent.repeat(2)}return\n`;
     codeSnippet += `${indent}}\n`;
     codeSnippet += `${indent}print(String(data: data, encoding: .utf8)!)\n`;

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -367,7 +367,7 @@ self = module.exports = {
     codeSnippet += '\nlet task = URLSession.shared.dataTask(with: request) { data, response, error in \n';
     codeSnippet += `${indent}guard let data = data else {\n`;
     codeSnippet += `${indent.repeat(2)}print(String(describing: error))\n`;
-    codeSnippet += `${indent.repeat(2)}semaphore.signal()`;
+    codeSnippet += `${indent.repeat(2)}semaphore.signal()\n`;
     codeSnippet += `${indent.repeat(2)}return\n`;
     codeSnippet += `${indent}}\n`;
     codeSnippet += `${indent}print(String(data: data, encoding: .utf8)!)\n`;


### PR DESCRIPTION
In the guarded fail case the semaphore wasn't being signaled and thus the 'program' would lock up.
Added a `semaphore.signal()` to the guard body