### PR TITLE
Python - Requests Keyword Arguments

### DIFF
--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -166,8 +166,8 @@ self = module.exports = {
     snippet += `response = requests.request("${request.method}", url, headers=headers`;
 
     snippet += request.body && request.body.mode && request.body.mode === 'formdata' ?
-      ', data = payload, files = files' : ', data = payload';
-    snippet += !options.followRedirect ? ', allow_redirects = False' : '';
+      ', data=payload, files=files' : ', data=payload';
+    snippet += !options.followRedirect ? ', allow_redirects=False' : '';
     snippet += options.requestTimeout !== 0 ? `, timeout=${options.requestTimeout}` : '';
     snippet += ')\n\n';
     snippet += 'print(response.text.encode(\'utf8\'))\n';

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -20,11 +20,11 @@ module.exports = function (request, indentation, bodyTrim) {
     switch (request.body.mode) {
       case 'raw':
         if (!_.isEmpty(request.body[request.body.mode])) {
-          requestBody += `payload = ${sanitize(request.body[request.body.mode],
+          requestBody += `payload=${sanitize(request.body[request.body.mode],
             request.body.mode, bodyTrim)}\n`;
         }
         else {
-          requestBody = 'payload  = {}\n';
+          requestBody = 'payload={}\n';
         }
         return requestBody;
       // eslint-disable-next-line no-case-declarations
@@ -37,7 +37,7 @@ module.exports = function (request, indentation, bodyTrim) {
         catch (e) {
           graphqlVariables = {};
         }
-        requestBody += `payload = ${sanitize(JSON.stringify({
+        requestBody += `payload=${sanitize(JSON.stringify({
           query: query,
           variables: graphqlVariables
         }),
@@ -50,10 +50,10 @@ module.exports = function (request, indentation, bodyTrim) {
             return `${sanitize(value.key, request.body.mode, bodyTrim)}=` +
                         `${sanitize(value.value, request.body.mode, bodyTrim)}`;
           });
-          requestBody += `payload = '${bodyDataMap.join('&')}'\n`;
+          requestBody += `payload='${bodyDataMap.join('&')}'\n`;
         }
         else {
-          requestBody = 'payload = {}\n';
+          requestBody = 'payload={}\n';
         }
         return requestBody;
       case 'formdata':
@@ -66,19 +66,19 @@ module.exports = function (request, indentation, bodyTrim) {
           bodyFileMap = _.map(_.filter(enabledBodyList, {'type': 'file'}), function (value) {
             return `${indentation}('${value.key}', open('${sanitize(value.src, request.body.mode, bodyTrim)}','rb'))`;
           });
-          requestBody = `payload = {${bodyDataMap.join(',\n')}}\nfiles = [\n${bodyFileMap.join(',\n')}\n]\n`;
+          requestBody = `payload={${bodyDataMap.join(',\n')}}\nfiles=[\n${bodyFileMap.join(',\n')}\n]\n`;
         }
         else {
-          requestBody = 'payload = {}\nfiles = {}\n';
+          requestBody = 'payload={}\nfiles={}\n';
         }
         return requestBody;
       case 'file':
-        // return `payload = {open('${request.body[request.body.mode].src}', 'rb').read()\n}`;
-        return 'payload = "<file contents here>"\n';
+        // return `payload={open('${request.body[request.body.mode].src}', 'rb').read()\n}`;
+        return 'payload="<file contents here>"\n';
       default:
-        return 'payload = {}\n';
+        return 'payload={}\n';
     }
   }
-  return 'payload = {}\n';
+  return 'payload={}\n';
 }
 ;

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -18,7 +18,7 @@ describe('Python- Requests converter', function () {
         expect.fail(null, null, err);
       }
       expect(snippet).to.be.a('string');
-      expect(snippet).to.not.include('allow_redirects = False, allow_redirects = false');
+      expect(snippet).to.not.include('allow_redirects=False, allow_redirects=false');
     });
   });
 
@@ -31,8 +31,8 @@ describe('Python- Requests converter', function () {
         expect.fail(null, null, err);
       }
       expect(snippet).to.be.a('string');
-      expect(snippet).to.include('allow_redirects = False');
-      expect(snippet).to.not.include('allow_redirects = false');
+      expect(snippet).to.include('allow_redirects=False');
+      expect(snippet).to.not.include('allow_redirects=false');
     });
   });
 


### PR DESCRIPTION
Removes the spaces surrounding the keyword arguments, as per PEP 8 style guide for unannotated function parameters.

https://www.python.org/dev/peps/pep-0008/

Python - Requests code snippet was:
`response = requests.request("GET", url, headers=headers, data = payload, allow_redirects = False)`

now becomes:
`response = requests.request("GET", url, headers=headers, data=payload, allow_redirects=False)`