### PR TITLE
Change nodejs-axios snippet to use async/await

### DIFF
--- a/codegens/nodejs-axios/lib/axios.js
+++ b/codegens/nodejs-axios/lib/axios.js
@@ -132,23 +132,26 @@ function makeSnippet (request, indentString, options) {
   snippet += ' config = {\n';
   snippet += configArray.join(',\n') + '\n';
   snippet += '};\n\n';
-  snippet += 'axios(config)\n';
   if (options.ES6_enabled) {
-    snippet += '.then((response) => {\n';
+    snippet += 'async function makeCall(config) {\n';
+    snippet += indentString + 'try {\n';
+    snippet += indentString + indentString + 'const response = await axios(config);\n';
+    snippet += indentString + indentString + 'console.log(JSON.stringify(response.data));\n';
+    snippet += indentString + '} catch (error) {\n';
+    snippet += indentString + indentString + 'console.log(error) {\n';
+    snippet += indentString + '}\n';
+    snippet += '}\n'
+    snippet += 'makeCall(config);'
   }
   else {
+    snippet += 'axios(config)\n';
     snippet += '.then(function (response) {\n';
-  }
-  snippet += indentString + 'console.log(JSON.stringify(response.data));\n';
-  snippet += '})\n';
-  if (options.ES6_enabled) {
-    snippet += '.catch((error) => {\n';
-  }
-  else {
+    snippet += indentString + 'console.log(JSON.stringify(response.data));\n';
+    snippet += '})\n';
     snippet += '.catch(function (error) {\n';
+    snippet += indentString + 'console.log(error);\n';
+    snippet += '});\n';
   }
-  snippet += indentString + 'console.log(error);\n';
-  snippet += '});\n';
 
   return snippet;
 }
@@ -181,7 +184,7 @@ function getOptions () {
       type: 'positiveInteger',
       default: 0,
       description: 'Set number of milliseconds the request should wait for a response' +
-    ' before timing out (use 0 for infinity)'
+      ' before timing out (use 0 for infinity)'
     },
     {
       name: 'Follow redirects',

--- a/codegens/nodejs-axios/lib/axios.js
+++ b/codegens/nodejs-axios/lib/axios.js
@@ -138,7 +138,7 @@ function makeSnippet (request, indentString, options) {
     snippet += indentString + indentString + 'const response = await axios(config);\n';
     snippet += indentString + indentString + 'console.log(JSON.stringify(response.data));\n';
     snippet += indentString + '} catch (error) {\n';
-    snippet += indentString + indentString + 'console.log(error) {\n';
+    snippet += indentString + indentString + 'console.log(error);\n';
     snippet += indentString + '}\n';
     snippet += '}\n'
     snippet += 'makeCall(config);'


### PR DESCRIPTION
resolves #302 
`nodejs-axios` snippet now include async/await.

Snippets for `javascript` don't use async/await as well but there is no `ES6_enabled` option, so I wasn't sure if I should change the snippets to use features of ES6 by default, so I didn't change them. 

(I would love to contribute something more significant to Postman)  