### PR TITLE
Fix the type of output for http codegen docs

### DIFF
--- a/codegens/http/README.md
+++ b/codegens/http/README.md
@@ -1,6 +1,6 @@
 # codegen-http
 
-> Converts Postman-SDK Request into code snippet for cURL.
+> Converts Postman-SDK Request into code snippet for RAW HTTP request.
 
 #### Prerequisites
 To run Code-Gen, ensure that you have NodeJS >= v8. A copy of the NodeJS installable can be downloaded from 


### PR DESCRIPTION
Changed the type of output from ```cURL``` into ```RAW HTTP request``` in the README file of codegens/http folder.
I felt this is a minor change so didn't open an issue for this