### PR TITLE
Fix incorrect variable usage in NodeJS native template

### DIFF
--- a/codegens/nodejs-native/lib/request.js
+++ b/codegens/nodejs-native/lib/request.js
@@ -168,7 +168,7 @@ function makeSnippet (request, indentString, options) {
   }
   else {
     snippet += indentString + 'res.on("end", function (chunk) {\n';
-    snippet += indentString.repeat(2) + 'var body = Buffer.concat(chunks);\n';
+    snippet += indentString.repeat(2) + 'var body = Buffer.concat(chunk);\n';
   }
   snippet += indentString.repeat(2) + 'console.log(body.toString());\n';
   snippet += indentString + '});\n\n';


### PR DESCRIPTION
Current template in NodeJS Native:

<img width="317" alt="Screenshot 2020-09-08 at 10 58 40 PM" src="https://user-images.githubusercontent.com/11012686/92508854-ef8e9780-f226-11ea-8fbe-5f752c356c65.png">

Here `chunks` is not defined and should have been `chunk`