### PR TITLE
Replace double-quotes by single-quotes in codegen/php-curl

### DIFF
--- a/codegens/php-curl/lib/php-curl.js
+++ b/codegens/php-curl/lib/php-curl.js
@@ -19,8 +19,8 @@ function getHeaders (request, indentation) {
   if (!_.isEmpty(headerArray)) {
     headerArray = _.reject(headerArray, 'disabled');
     headerMap = _.map(headerArray, function (header) {
-      return `${indentation.repeat(2)}"${sanitize(header.key, 'header', true)}: ` +
-            `${sanitize(header.value, 'header')}"`;
+      return `${indentation.repeat(2)}'${sanitize(header.key, 'header', true)}: ` +
+            `${sanitize(header.value, 'header')}'`;
     });
     return `${indentation}CURLOPT_HTTPHEADER => array(\n${headerMap.join(',\n')}\n${indentation}),\n`;
   }
@@ -112,14 +112,14 @@ self = module.exports = {
     }
     snippet = '<?php\n\n$curl = curl_init();\n\n';
     snippet += 'curl_setopt_array($curl, array(\n';
-    snippet += `${indentation}CURLOPT_URL => "${sanitize(finalUrl, 'url')}",\n`;
+    snippet += `${indentation}CURLOPT_URL => '${sanitize(finalUrl, 'url')}',\n`;
     snippet += `${indentation}CURLOPT_RETURNTRANSFER => true,\n`;
-    snippet += `${indentation}CURLOPT_ENCODING => "",\n`;
+    snippet += `${indentation}CURLOPT_ENCODING => '',\n`;
     snippet += `${indentation}CURLOPT_MAXREDIRS => 10,\n`;
     snippet += `${indentation}CURLOPT_TIMEOUT => ${options.requestTimeout},\n`;
     snippet += `${indentation}CURLOPT_FOLLOWLOCATION => ${options.followRedirect},\n`;
     snippet += `${indentation}CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n`;
-    snippet += `${indentation}CURLOPT_CUSTOMREQUEST => "${request.method}",\n`;
+    snippet += `${indentation}CURLOPT_CUSTOMREQUEST => '${request.method}',\n`;
 
     // The following code handles multiple files in the same formdata param.
     // It removes the form data params where the src property is an array of filepath strings

--- a/codegens/php-curl/lib/util/parseBody.js
+++ b/codegens/php-curl/lib/util/parseBody.js
@@ -20,7 +20,7 @@ module.exports = function (request, trimRequestBody, indentation) {
       case 'raw':
         if (!_.isEmpty(request.body[request.body.mode])) {
           requestBody += `${indentation}CURLOPT_POSTFIELDS =>` +
-                        `${sanitize(request.body[request.body.mode], request.body.mode, trimRequestBody)},\n`;
+                        `'${sanitize(request.body[request.body.mode], request.body.mode, trimRequestBody)}',\n`;
         }
         return requestBody;
       // eslint-disable-next-line no-case-declarations
@@ -34,10 +34,10 @@ module.exports = function (request, trimRequestBody, indentation) {
           graphqlVariables = {};
         }
         requestBody += `${indentation}CURLOPT_POSTFIELDS =>` +
-          `${sanitize(JSON.stringify({
+          `'${sanitize(JSON.stringify({
             query: query,
             variables: graphqlVariables
-          }), 'raw', trimRequestBody)},\n`;
+          }), 'raw', trimRequestBody)}',\n`;
         return requestBody;
       case 'urlencoded':
         enabledBodyList = _.reject(request.body[request.body.mode], 'disabled');
@@ -46,7 +46,7 @@ module.exports = function (request, trimRequestBody, indentation) {
             return `${sanitize(value.key, request.body.mode, trimRequestBody)}=` +
                             `${sanitize(value.value, request.body.mode, trimRequestBody)}`;
           });
-          requestBody = `${indentation}CURLOPT_POSTFIELDS => "${bodyMap.join('&')}",\n`;
+          requestBody = `${indentation}CURLOPT_POSTFIELDS => '${bodyMap.join('&')}',\n`;
         }
         return requestBody;
       case 'formdata':

--- a/codegens/php-curl/lib/util/sanitize.js
+++ b/codegens/php-curl/lib/util/sanitize.js
@@ -15,8 +15,6 @@ module.exports = {
     inputString = inputTrim && typeof inputTrim === 'boolean' ? inputString.trim() : inputString;
     if (escapeCharFor && typeof escapeCharFor === 'string') {
       switch (escapeCharFor) {
-        case 'raw':
-          return JSON.stringify(inputString);
         case 'urlencoded':
           return escape(inputString);
         default:

--- a/codegens/php-curl/lib/util/sanitize.js
+++ b/codegens/php-curl/lib/util/sanitize.js
@@ -19,14 +19,8 @@ module.exports = {
           return JSON.stringify(inputString);
         case 'urlencoded':
           return escape(inputString);
-        case 'formdata':
-          return inputString.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
-        case 'file':
-          return inputString.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
-        case 'header':
-          return inputString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         default:
-          return inputString.replace(/"/g, '\\"');
+          return inputString.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
       }
     }
     return inputString;

--- a/codegens/php-curl/test/unit/converter.test.js
+++ b/codegens/php-curl/test/unit/converter.test.js
@@ -32,7 +32,7 @@ describe('php-curl converter', function () {
       }
       expect(snippet).to.be.a('string');
       // one extra space in matching the output because we add key:<space>value in the snippet
-      expect(snippet).to.include('"key_containing_whitespaces:   value_containing_whitespaces  "');
+      expect(snippet).to.include('\'key_containing_whitespaces:   value_containing_whitespaces  \'');
     });
   });
 

--- a/test/codegen/newman/fixtures/basicCollection.json
+++ b/test/codegen/newman/fixtures/basicCollection.json
@@ -330,7 +330,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "var val = 6;\nconsole.log(val);"
+					"raw": "var val = 6;\nconsole.log(val);console.log('$text');\n"
 				},
 				"url": {
 					"raw": "https://postman-echo.com/post",


### PR DESCRIPTION
Solves #284 

PHP expands variables and escape sequences for special characters inside double-quotes. This is a problem if body of a request contains `$` sign. Using single-quotes solves this problem. This is an alternative solution to #285 .