### PR TITLE
Add optional import of FoundationNetworking in swift codegen to make it work with Swift 5.x

### DIFF
--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -335,7 +335,8 @@ self = module.exports = {
     requestBody = (request.body ? request.body.toJSON() : {});
     bodySnippet = parseBody(requestBody, trim, indent);
 
-    codeSnippet = 'import Foundation\n\n';
+    codeSnippet = 'import Foundation\n';
+    codeSnippet += '#if canImport(FoundationNetworking)\nimport FoundationNetworking\n#endif\n\n';
     codeSnippet += 'var semaphore = DispatchSemaphore (value: 0)\n\n';
     if (bodySnippet !== '') {
       codeSnippet += `${bodySnippet}\n\n`;

--- a/codegens/swift/test/newman/newman.test.js
+++ b/codegens/swift/test/newman/newman.test.js
@@ -9,7 +9,7 @@ describe('Convert for different types of request', function () {
     // if running locally on mac change the runScript to 'swift snippet.swift'
     testConfig = {
       fileName: 'snippet.swift',
-      runScript: 'swift-5.0.1-RELEASE-ubuntu16.04/usr/bin/./swift snippet.swift',
+      runScript: 'swift-5.3-RELEASE-ubuntu16.04/usr/bin/swift snippet.swift',
       skipCollections: ['sameNameHeadersCollection']
     };
   runNewmanTest(convert, options, testConfig);

--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -36,9 +36,9 @@ pushd ./codegens/swift &>/dev/null;
   sudo apt-get update
   sudo apt-get install clang-3.6 libicu-dev libpython2.7 -y
   sudo apt-get install libcurl3 libpython2.7-dev -y
-  sudo wget https://swift.org/builds/swift-5.0.1-release/ubuntu1604/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu16.04.tar.gz
-  sudo tar xzf swift-5.0.1-RELEASE-ubuntu16.04.tar.gz
-  sudo chmod 777 swift-5.0.1-RELEASE-ubuntu16.04/usr/lib/swift/CoreFoundation/module.map
+  sudo wget https://swift.org/builds/swift-5.3-release/ubuntu1604/swift-5.3-RELEASE/swift-5.3-RELEASE-ubuntu16.04.tar.gz
+  sudo tar xzf swift-5.3-RELEASE-ubuntu16.04.tar.gz
+  sudo chmod 777 swift-5.3-RELEASE-ubuntu16.04/usr/lib/swift/CoreFoundation/module.map
 popd &>/dev/null;
 
 echo "Installing dependencies required for tests in codegens/csharp-restsharp"


### PR DESCRIPTION
Fix #353. 