### PR TITLE
Run tests for both Python 2 and Python 3 for python-requests

### DIFF
--- a/codegens/python-requests/test/newman/newman.test.js
+++ b/codegens/python-requests/test/newman/newman.test.js
@@ -11,6 +11,9 @@ describe('Convert for different types of request', function () {
         fileName: 'codesnippet.py',
         runScript: 'python codesnippet.py',
         compileScript: null,
+        // Requests does not support multipart/form-data unless we are also
+        // uploading a file. Headers are stored in a dict so we cannot have
+        // two headers with same key
         skipCollections: ['formdataCollection', 'sameNameHeadersCollection']
       };
     runNewmanTest(convert, options, testConfig);
@@ -25,6 +28,9 @@ describe('Convert for different types of request', function () {
         fileName: 'codesnippet.py',
         runScript: 'python3 codesnippet.py',
         compileScript: null,
+        // Requests does not support multipart/form-data unless we are also
+        // uploading a file. Headers are stored in a dict so we cannot have
+        // two headers with same key
         skipCollections: ['formdataCollection', 'sameNameHeadersCollection']
       };
     runNewmanTest(convert, options, testConfig);

--- a/codegens/python-requests/test/newman/newman.test.js
+++ b/codegens/python-requests/test/newman/newman.test.js
@@ -2,17 +2,35 @@ var runNewmanTest = require('../../../../test/codegen/newman/newmanTestUtil').ru
   convert = require('../../lib/index').convert;
 
 describe('Convert for different types of request', function () {
-  var options = {
-      indentType: 'Space',
-      indentCount: 4
-    },
-    testConfig = {
-      fileName: 'codesnippet.py',
-      runScript: 'python codesnippet.py',
-      compileScript: null,
-      skipCollections: ['formdataCollection', 'sameNameHeadersCollection']
-    };
-  runNewmanTest(convert, options, testConfig);
+  describe('Run tests for Python 2', function () {
+    var options = {
+        indentType: 'Space',
+        indentCount: 4
+      },
+      testConfig = {
+        fileName: 'codesnippet.py',
+        runScript: 'python codesnippet.py',
+        compileScript: null,
+        skipCollections: ['formdataCollection', 'sameNameHeadersCollection']
+      };
+    runNewmanTest(convert, options, testConfig);
+  });
+
+  describe('Run tests  for Python 3', function () {
+    var options = {
+        indentType: 'Space',
+        indentCount: 4
+      },
+      testConfig = {
+        fileName: 'codesnippet.py',
+        runScript: 'python3 codesnippet.py',
+        compileScript: null,
+        skipCollections: ['formdataCollection', 'sameNameHeadersCollection']
+      };
+    runNewmanTest(convert, options, testConfig);
+
+  });
 
 });
+
 


### PR DESCRIPTION
Currently the tests are only running for Python 2 in the `python-requests` codegen. I have enabled them for both 2 and 3. `python-http.client` is Python 3 only, so there was no need for it in that.