### PR TITLE
Implement option shellType for curl codegen

### DIFF
--- a/codegens/curl/README.md
+++ b/codegens/curl/README.md
@@ -3,7 +3,7 @@
 > Converts Postman-SDK Request into code snippet for cURL.
 
 #### Prerequisites
-To run Code-Gen, ensure that you have NodeJS >= v8. A copy of the NodeJS installable can be downloaded from 
+To run Code-Gen, ensure that you have NodeJS >= v8. A copy of the NodeJS installable can be downloaded from
 
 ## Using the Module
 The module will expose an object which will have property `convert` which is the function for converting the Postman-SDK request to cURL code snippet and `getOptions` function which returns an array of supported options.
@@ -21,12 +21,13 @@ Convert function takes three parameters
     * `requestTimeout` - Integer denoting time after which the request will bail out in milli-seconds
     * `multiLine` - Boolean denoting whether to output code snippet with multi line breaks
     * `longFormat` - Boolean denoting whether to use longform cURL options in snippet
+    * `shellType` - Enum denoting which type of shell curl will run in
 
 * `callback` - callback function with first parameter as error and second parameter as string for code snippet
 
 ##### Example:
 ```js
-var request = new sdk.Request('www.google.com'),  //using postman sdk to create request  
+var request = new sdk.Request('www.google.com'),  //using postman sdk to create request
     options = {
         indentCount: 3,
         indentType: 'Space',

--- a/codegens/curl/README.md
+++ b/codegens/curl/README.md
@@ -21,7 +21,7 @@ Convert function takes three parameters
     * `requestTimeout` - Integer denoting time after which the request will bail out in milli-seconds
     * `multiLine` - Boolean denoting whether to output code snippet with multi line breaks
     * `longFormat` - Boolean denoting whether to use longform cURL options in snippet
-    * `shellType` - Enum denoting which type of shell curl will run in
+    * `shellType` - String denoting which type of shell curl will run in
 
 * `callback` - callback function with first parameter as error and second parameter as string for code snippet
 

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -15,7 +15,7 @@ self = module.exports = {
     options = sanitizeOptions(options, self.getOptions());
 
     var indent, trim, headersData, body, redirect, timeout, multiLine,
-      format, snippet, silent, url;
+      format, snippet, silent, url, shellType, lineContinuationCharacter, quoteType;
 
     redirect = options.followRedirect;
     timeout = options.requestTimeout;
@@ -23,6 +23,22 @@ self = module.exports = {
     format = options.longFormat;
     trim = options.trimRequestBody;
     silent = options.silent;
+    shellType = options.shellType;
+
+    switch (shellType) {
+      case 'cmd.exe':
+        lineContinuationCharacter = '^';
+        quoteType = '"';
+        break;
+      case 'powershell':
+        lineContinuationCharacter = '`';
+        quoteType = '\'';
+        break;
+      default:
+        lineContinuationCharacter = '\\';
+        quoteType = '\'';
+        break;
+    }
 
     snippet = silent ? `curl ${form('-s', format)}` : 'curl';
     if (redirect) {
@@ -33,17 +49,17 @@ self = module.exports = {
     }
     if (multiLine) {
       indent = options.indentType === 'Tab' ? '\t' : ' ';
-      indent = ' ' + options.lineContinuationCharacter + '\n' + indent.repeat(options.indentCount); // eslint-disable-line max-len
+      indent = ' ' + lineContinuationCharacter + '\n' + indent.repeat(options.indentCount); // eslint-disable-line max-len
     }
     else {
       indent = ' ';
     }
     url = getUrlStringfromUrlObject(request.url);
     if (request.method === 'HEAD') {
-      snippet += ` ${form('-I', format)} '${url}'`;
+      snippet += ` ${form('-I', format)} ${quoteType + url + quoteType}`;
     }
     else {
-      snippet += ` ${form('-X', format)} ${request.method} '${url}'`;
+      snippet += ` ${form('-X', format)} ${request.method} ${quoteType + url + quoteType}`;
     }
 
     if (request.body && !request.headers.has('Content-Type')) {
@@ -64,7 +80,8 @@ self = module.exports = {
     if (headersData) {
       headersData = _.reject(headersData, 'disabled');
       _.forEach(headersData, (header) => {
-        snippet += indent + `${form('-H', format)} '${sanitize(header.key, true)}: ${sanitize(header.value)}'`;
+        snippet += indent + `${form('-H', format)} ${quoteType + sanitize(header.key, true)}:`;
+        snippet += ` ${sanitize(header.value) + quoteType}`;
       });
     }
 
@@ -114,12 +131,12 @@ self = module.exports = {
                 // Using the long form below without considering the longFormat option,
                 // to generate more accurate and correct snippet
                 snippet += indent + '--data-urlencode';
-                snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
+                snippet += ` ${quoteType + sanitize(data.key, trim)}=${sanitize(data.value, trim) + quoteType}`;
               }
             });
             break;
           case 'raw':
-            snippet += indent + `--data-raw '${sanitize(body.raw.toString(), trim)}'`;
+            snippet += indent + `--data-raw ${quoteType + sanitize(body.raw.toString(), trim) + quoteType}`;
             break;
           case 'graphql':
             // eslint-disable-next-line no-case-declarations
@@ -131,31 +148,31 @@ self = module.exports = {
             catch (e) {
               graphqlVariables = {};
             }
-            snippet += indent + `--data-raw '${sanitize(JSON.stringify({
+            snippet += indent + `--data-raw ${quoteType + sanitize(JSON.stringify({
               query: query,
               variables: graphqlVariables
-            }), trim)}'`;
+            }), trim) + quoteType}`;
             break;
           case 'formdata':
             _.forEach(body.formdata, function (data) {
               if (!(data.disabled)) {
                 if (data.type === 'file') {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` '${sanitize(data.key, trim)}=@${sanitize(data.src, trim)}'`;
+                  snippet += ` ${quoteType + sanitize(data.key, trim)}=@${sanitize(data.src, trim) + quoteType}`;
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` '${sanitize(data.key, trim)}=${sanitize(data.value, trim)}'`;
+                  snippet += ` ${quoteType + sanitize(data.key, trim)}=${sanitize(data.value, trim) + quoteType}`;
                 }
               }
             });
             break;
           case 'file':
             snippet += indent + '--data-binary';
-            snippet += ` '@${sanitize(body[body.mode].src, trim)}'`;
+            snippet += ` ${quoteType}@${sanitize(body[body.mode].src, trim) + quoteType}`;
             break;
           default:
-            snippet += `${form('-d', format)} ''`;
+            break;
         }
       }
     }
@@ -178,13 +195,13 @@ self = module.exports = {
         description: 'Use the long form for cURL options (--header instead of -H)'
       },
       {
-        name: 'Line continuation character',
-        id: 'lineContinuationCharacter',
-        availableOptions: ['\\', '^'],
+        name: 'Shell type',
+        id: 'shellType',
+        availableOptions: ['sh', 'cmd.exe', 'powershell'],
         type: 'enum',
-        default: '\\',
-        description: 'Set a character used to mark the continuation of a statement on the next line ' +
-          '(generally, \\ for OSX/Linux, ^ for Windows)'
+        default: 'sh',
+        description: 'Set the shell where curl will be run. This will set the appropriate type for ' +
+          'quotes (\' or ") and line continuation character (\\, ^ or `)'
       },
       {
         name: 'Set request timeout',

--- a/codegens/curl/test/newman/newman.test.js
+++ b/codegens/curl/test/newman/newman.test.js
@@ -11,7 +11,7 @@ describe('Convert for different types of request', function () {
       followRedirect: true,
       longFormat: true,
       silent: true,
-      lineContinuationCharacter: '\\'
+      shellType: 'sh'
     };
 
   runNewmanTest(convert, options, testConfig);

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -8,7 +8,7 @@ describe('curl convert function', function () {
     var request, options, snippetArray, line;
 
     it('should return snippet with carat(^) as line continuation ' +
-            'character for multiline code generation', function () {
+      'character for multiline code generation and double quotes for quoting', function () {
       request = new sdk.Request({
         'method': 'POST',
         'header': [],
@@ -19,7 +19,7 @@ describe('curl convert function', function () {
       });
       options = {
         multiLine: true,
-        lineContinuationCharacter: '^'
+        shellType: 'cmd.exe'
       };
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -31,6 +31,34 @@ describe('curl convert function', function () {
           line = snippetArray[i];
           expect(line.charAt(line.length - 1)).to.equal('^');
         }
+        expect(snippet).to.contain('"');
+      });
+    });
+    it('should return snippet with backtick(`) as line continuation ' +
+    'character for multiline code generation and single quotes for quoting', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'body': {
+          'mode': 'raw',
+          'raw': ''
+        }
+      });
+      options = {
+        multiLine: true,
+        shellType: 'powershell'
+      };
+      convert(request, options, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        snippetArray = snippet.split('\n');
+        // Ignoring the last line as there is no line continuation character at last line
+        for (var i = 0; i < snippetArray.length - 1; i++) {
+          line = snippetArray[i];
+          expect(line.charAt(line.length - 1)).to.equal('`');
+        }
+        expect(snippet).to.contain('\'');
       });
     });
 
@@ -96,7 +124,7 @@ describe('curl convert function', function () {
       });
       options = {
         multiLine: true,
-        lineContinuationCharacter: '\\'
+        shellType: 'sh'
       };
       convert(request, options, function (error, snippet) {
         if (error) {

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -80,7 +80,7 @@ const expectedOptions = {
     'silent',
     'includeBoilerplate',
     'followRedirect',
-    'lineContinuationCharacter',
+    'shellType',
     'protocol',
     'useMimeType',
     'ES6_enabled'


### PR DESCRIPTION
Fixes #248 and fixes #186. Alternative to #251 and #392. 

We currently have an option called 'lineContinuationCharacter" to choose between \ and ^ as line continuation character for Unix shells and Windows cmd.exe respectively. But powershell uses ` as for escaping newlines, this is the cause of #186. These shells also differ in how they treat single quote and double quotes. Specifically, cmd treats single quotes as an ordinary character and passes it as it is to curl, which is the cause of #248. 

Instead of adding separate option for these, I have added a shellType option so the user can simply choose which shell he is going to run curl in and we will generate the correct code for that.