### PR TITLE
Add semicolon after header key in curl codegen if the value is empty string.

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -69,7 +69,17 @@ self = module.exports = {
     if (headersData) {
       headersData = _.reject(headersData, 'disabled');
       _.forEach(headersData, (header) => {
-        snippet += indent + `${form('-H', format)} '${sanitize(header.key, true)}: ${sanitize(header.value)}'`;
+        if (!header.key) {
+          return;
+        }
+        snippet += indent + `${form('-H', format)} '${sanitize(header.key, true)}`;
+        // If the header value is an empty string then add a semicolon after key
+        // otherwise, they header would be ignored by curl
+        if (header.value) {
+          snippet += `: ${sanitize(header.value)}'`;
+        } else {
+          snippet += ';\'';
+        }
       });
     }
 

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -74,7 +74,7 @@ self = module.exports = {
         }
         snippet += indent + `${form('-H', format)} '${sanitize(header.key, true)}`;
         // If the header value is an empty string then add a semicolon after key
-        // otherwise, they header would be ignored by curl
+        // otherwise the header would be ignored by curl
         if (header.value) {
           snippet += `: ${sanitize(header.value)}'`;
         }

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -77,7 +77,8 @@ self = module.exports = {
         // otherwise, they header would be ignored by curl
         if (header.value) {
           snippet += `: ${sanitize(header.value)}'`;
-        } else {
+        }
+        else {
           snippet += ';\'';
         }
       });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -33,6 +33,7 @@ describe('curl convert function', function () {
         }
       });
     });
+
     it('should return snippet with url in single quote(\')', function () {
       request = new sdk.Request({
         'method': 'POST',
@@ -54,6 +55,7 @@ describe('curl convert function', function () {
         expect(snippetArray[4][0]).to.equal('\'');
       });
     });
+
     it('should return snippet with url in double quote(")', function () {
       request = new sdk.Request({
         'method': 'POST',
@@ -73,6 +75,36 @@ describe('curl convert function', function () {
 
         snippetArray = snippet.split(' ');
         expect(snippetArray[4][0]).to.equal('"');
+      });
+    });
+
+    it('should add semicolon after header key, if the value is empty string', function () {
+      request = new sdk.Request({
+        'method': 'GET',
+        'header': [
+          {
+            'key': 'hello',
+            'value': ''
+          }
+        ],
+        'url': {
+          'raw': 'https://postman-echo.com/get',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('--header \'hello;\'');
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/postmanlabs/postman-app-support/issues/9212