### PR TITLE
Add Content-type for form-data fields if is present in the request.

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -150,7 +150,11 @@ self = module.exports = {
                 }
                 else {
                   snippet += indent + `${form('-F', format)}`;
-                  snippet += ` '${sanitize(data.key, trim)}="${sanitize(data.value, trim, true, true)}"'`;
+                  snippet += ` '${sanitize(data.key, trim)}="${sanitize(data.value, trim, true, true)}"`;
+                  if (data.contentType) {
+                    snippet += `;type=${data.contentType}`;
+                  }
+                  snippet += '\'';
                 }
               }
             });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -160,7 +160,7 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.contain('--form \'json="{"hello": "world"}";type=application/json\'');
+        expect(snippet).to.contain('--form \'json="{\\"hello\\": \\"world\\"}";type=application/json\'');
 
       });
     });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -129,6 +129,42 @@ describe('curl convert function', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('--form \'json="{"hello": "world"}";type=application/json\'');
+
+      });
+    });
+
     it('should parse header with string value properly', function () {
       request = new sdk.Request({
         'method': 'POST',

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -77,11 +77,21 @@ function parseFormData (body, trim, indent) {
         bodySnippet += `${indent}defer file.Close()\n`;
         bodySnippet += `${indent}part${index + 1},
          errFile${index + 1} := writer.CreateFormFile("${sanitize(data.key, trim)}",` +
-                        `filepath.Base("${data.src}"))\n`;
+          `filepath.Base("${data.src}"))\n`;
         bodySnippet += `${indent}_, errFile${index + 1} = io.Copy(part${index + 1}, file)\n`;
         bodySnippet += `${indent}if errFile${index + 1} != nil {` +
           `\n${indent.repeat(2)}fmt.Println(errFile${index + 1})\n` +
           `${indent.repeat(2)}return\n${indent}}\n`;
+      }
+      else if (data.contentType) {
+        bodySnippet += `\n${indent}mimeHeader${index + 1} := make(map[string][]string)\n`;
+        bodySnippet += `${indent}mimeHeader${index + 1}["Content-Disposition"] = `;
+        bodySnippet += `append(mimeHeader${index + 1}["Content-Disposition"], "form-data; `;
+        bodySnippet += `name=\\"${sanitize(data.key, trim)}\\"")\n`;
+        bodySnippet += `${indent}mimeHeader${index + 1}["Content-Type"] = append(`;
+        bodySnippet += `mimeHeader${index + 1}["Content-Type"], "${data.contentType}")\n`;
+        bodySnippet += `${indent}fieldWriter${index + 1}, _ := writer.CreatePart(mimeHeader${index + 1})\n`;
+        bodySnippet += `${indent}fieldWriter${index + 1}.Write([]byte("${sanitize(data.value, trim)}"))\n\n`;
       }
       else {
         bodySnippet += `${indent}_ = writer.WriteField("${sanitize(data.key, trim)}",`;

--- a/codegens/golang/test/unit/convert.test.js
+++ b/codegens/golang/test/unit/convert.test.js
@@ -65,6 +65,45 @@ describe('Golang convert function', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('mimeHeader1 := make(map[string][]string)');
+        expect(snippet).to.contain('mimeHeader1["Content-Disposition"] = append(mimeHeader1["Content-Disposition"], "form-data; name=\\"json\\"")'); // eslint-disable-line max-len
+        expect(snippet).to.contain('mimeHeader1["Content-Type"] = append(mimeHeader1["Content-Type"], "application/json")'); // eslint-disable-line max-len
+        expect(snippet).to.contain('fieldWriter1, _ := writer.CreatePart(mimeHeader1)');
+        expect(snippet).to.contain('fieldWriter1.Write([]byte("{\\"hello\\": \\"world\\"}"))');
+      });
+    });
+
     it('should add time converted to seconds when input is taken in milliseconds ', function () {
       request = new sdk.Request({
         'method': 'GET',

--- a/codegens/http/lib/util.js
+++ b/codegens/http/lib/util.js
@@ -195,6 +195,9 @@ function getBody (request, trimRequestBody) {
             if (property.type === 'text') {
               requestBody += 'Content-Disposition: form-data; name="';
               requestBody += `${(trimRequestBody ? property.key.trim() : property.key)}"\n`;
+              if (property.contentType) {
+                requestBody += `Content-Type: ${property.contentType}\n`;
+              }
               requestBody += `\n${(trimRequestBody ? property.value.trim() : property.value)}\n`;
             }
             else if (property.type === 'file') {

--- a/codegens/http/test/unit/converter.test.js
+++ b/codegens/http/test/unit/converter.test.js
@@ -279,7 +279,7 @@ describe('Converter test', function () {
   });
 
   it('should add content type if formdata field contains a content-type', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'body': {
         'mode': 'formdata',

--- a/codegens/http/test/unit/converter.test.js
+++ b/codegens/http/test/unit/converter.test.js
@@ -278,6 +278,41 @@ describe('Converter test', function () {
     });
   });
 
+  it('should add content type if formdata field contains a content-type', function () {
+    var request = new sdk.Request({
+      'method': 'POST',
+      'body': {
+        'mode': 'formdata',
+        'formdata': [
+          {
+            'key': 'json',
+            'value': '{"hello": "world"}',
+            'contentType': 'application/json',
+            'type': 'text'
+          }
+        ]
+      },
+      'url': {
+        'raw': 'http://postman-echo.com/post',
+        'host': [
+          'postman-echo',
+          'com'
+        ],
+        'path': [
+          'post'
+        ]
+      }
+    });
+
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      expect(snippet).to.contain('Content-Type: application/json');
+    });
+  });
+
   it('should not add extra newlines if there is no body or header present', function () {
     var request = new Request({
       'method': 'GET',

--- a/codegens/java-okhttp/lib/parseRequest.js
+++ b/codegens/java-okhttp/lib/parseRequest.js
@@ -44,8 +44,14 @@ function parseFormData (requestBody, indentString, trimFields) {
     }
     else {
       !data.value && (data.value = '');
-      body += indentString + '.addFormDataPart' +
-                    `("${sanitize(data.key, trimFields)}", "${sanitize(data.value, trimFields)}")\n`;
+      body += `${indentString}.addFormDataPart("${sanitize(data.key, trimFields)}",`;
+      if (data.contentType) {
+        body += ` null,\n${indentString.repeat(2)} RequestBody.create(MediaType.parse("${data.contentType}"),`;
+        body += ` "${sanitize(data.value, trimFields)}".getBytes()))\n`;
+      }
+      else {
+        body += `"${sanitize(data.value, trimFields)}")\n`;
+      }
     }
 
     return body;

--- a/codegens/java-okhttp/test/unit/convert.test.js
+++ b/codegens/java-okhttp/test/unit/convert.test.js
@@ -107,6 +107,41 @@ describe('okhttp convert function', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('RequestBody.create(MediaType.parse("application/json"), "{\\"hello\\": \\"world\\"}".getBytes()))'); // eslint-disable-line max-len
+      });
+    });
+
     it('should generate snippets for no files in form data', function () {
       var request = new sdk.Request({
         'method': 'POST',

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -62,7 +62,11 @@ function parseFormData (requestbody, indentString, trimField) {
     else {
       (!data.value) && (data.value = '');
       body += indentString + `.field("${sanitize(data.key, trimField)}", ` +
-                                    `"${sanitize(data.value, trimField)}")\n`;
+                                    `"${sanitize(data.value, trimField)}"`;
+      if (data.contentType) {
+        body += `, "${sanitize(data.contentType, trimField)}"`;
+      }
+      body += ')\n';
     }
     return body;
   }, '');
@@ -101,7 +105,7 @@ function parseBody (request, indentString, trimField) {
       case 'formdata':
         var formDataContent = parseFormData(request.body.toJSON(), indentString, trimField);
         if (!formDataContent.includes('.field("file", new File')) {
-          formDataContent = indentString + '.multiPartContent()' + formDataContent;
+          formDataContent = indentString + '.multiPartContent()\n' + formDataContent;
         }
         return formDataContent;
       case 'file':

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -89,6 +89,41 @@ describe('java unirest convert function for test collection', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('.field("json", "{\\"hello\\": \\"world\\"}", "application/json")');
+      });
+    });
+
     it('should include import statements, main class and print statements ' +
             'when includeBoilerplate is set to true', function () {
       request = new sdk.Request(mainCollection.item[0].request);

--- a/codegens/libcurl/lib/index.js
+++ b/codegens/libcurl/lib/index.js
@@ -171,6 +171,9 @@ self = module.exports = {
                 }
                 else {
                   snippet += indentString + `curl_mime_name(part, "${sanitize(data.key, trim)}");\n`;
+                  if (data.contentType) {
+                    snippet += indentString + `curl_mime_type(part, "${sanitize(data.contentType, trim)}");\n`;
+                  }
                   snippet += indentString +
                   `curl_mime_data(part, "${sanitize(data.value, trim)}", CURL_ZERO_TERMINATED);\n`;
                 }

--- a/codegens/libcurl/test/unit/convert.test.js
+++ b/codegens/libcurl/test/unit/convert.test.js
@@ -61,6 +61,41 @@ describe('libcurl convert function', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('curl_mime_type(part, "application/json");');
+      });
+    });
+
     it('should generate snippets for no files in form data', function () {
       var request = new sdk.Request({
         'method': 'POST',

--- a/codegens/nodejs-axios/lib/parseRequest.js
+++ b/codegens/nodejs-axios/lib/parseRequest.js
@@ -58,7 +58,11 @@ function parseFormData (body, trim, ES6_enabled) {
         bodySnippet += `data.append('${sanitize(data.key, trim)}', ${fileContent});\n`;
       }
       else {
-        bodySnippet += `data.append('${sanitize(data.key, trim)}', '${sanitize(data.value, trim)}');\n`;
+        bodySnippet += `data.append('${sanitize(data.key, trim)}', '${sanitize(data.value, trim)}'`;
+        if (data.contentType) {
+          bodySnippet += `, {contentType: '${sanitize(data.contentType, trim)}'}`;
+        }
+        bodySnippet += ');\n';
       }
     }
   });

--- a/codegens/nodejs-axios/test/unit/snippet.test.js
+++ b/codegens/nodejs-axios/test/unit/snippet.test.js
@@ -125,6 +125,41 @@ describe('nodejs-axios convert function', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('data.append(\'json\', \'{"hello": "world"}\', {contentType: \'application/json\'});'); // eslint-disable-line max-len
+      });
+    });
+
     it('should return snippet with proper semicolon placed where required', function () {
       // testing for the below snippet
       /*

--- a/codegens/nodejs-native/lib/parseRequest.js
+++ b/codegens/nodejs-native/lib/parseRequest.js
@@ -57,7 +57,12 @@ function generateMultipartFormData (requestbody) {
         else {
           // eslint-disable-next-line no-useless-escape
           const value = dataArrayElement.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-          accumalator.push(`name=\\"${key}\\"\\r\\n\\r\\n${value}\\r\\n`);
+          let field = `name=\\"${key}\\"\\r\\n`;
+          if (dataArrayElement.contentType) {
+            field += `Content-Type: ${dataArrayElement.contentType}\\r\\n`;
+          }
+          field += `\\r\\n${value}\\r\\n`;
+          accumalator.push(field);
         }
       }
       return accumalator;

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -124,6 +124,41 @@ describe('nodejs-native convert function', function () {
     });
   });
 
+  it('should add content type if formdata field contains a content-type', function () {
+    var request = new sdk.Request({
+      'method': 'POST',
+      'body': {
+        'mode': 'formdata',
+        'formdata': [
+          {
+            'key': 'json',
+            'value': '{"hello": "world"}',
+            'contentType': 'application/json',
+            'type': 'text'
+          }
+        ]
+      },
+      'url': {
+        'raw': 'http://postman-echo.com/post',
+        'host': [
+          'postman-echo',
+          'com'
+        ],
+        'path': [
+          'post'
+        ]
+      }
+    });
+
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      expect(snippet).to.contain('Content-Type: application/json');
+    });
+  });
+
   it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
     var request = new sdk.Request({
         'method': 'POST',

--- a/codegens/ocaml-cohttp/lib/ocaml.js
+++ b/codegens/ocaml-cohttp/lib/ocaml.js
@@ -83,7 +83,9 @@ function parseFormData (body, trim, indent) {
         }
         else {
           const value = sanitize(data.value, 'formdata-value', trim);
-          accumalator.push(`${indent}[| ("name", "${key}"); ("value", "${value}") |]`);
+          accumalator.push(`${indent}[| ("name", "${key}"); ("value", "${value}")` +
+            (data.contentType ? `; ("contentType", "${data.contentType}")` : '') +
+            ' |]');
         }
       }
       return accumalator;
@@ -100,7 +102,13 @@ function parseFormData (body, trim, indent) {
   bodySnippet += 'name=\\"" ^ paramName ^ "\\"" in\n';
   bodySnippet += `${indent}if paramType = "value" then (\n`;
   bodySnippet += `${indent.repeat(2)}let (_, paramValue) = parameters.(x).(1) in\n`;
-  bodySnippet += `${indent.repeat(2)}postData := !postData ^ accum ^ "\\r\\n\\r\\n" ^ paramValue ^ "\\r\\n";\n`;
+  bodySnippet += `${indent.repeat(2)}postData := if Array.length parameters.(x) == 3 then (\n`;
+  bodySnippet += `${indent.repeat(3)}let (_, contentType) = parameters.(x).(2) in\n`;
+  bodySnippet += `${indent.repeat(3)}!postData ^ accum ^ "\\r\\n" ^ "Content-Type: " ^ contentType ^`;
+  bodySnippet += ' "\\r\\n\\r\\n" ^ paramValue ^ "\\r\\n"\n';
+  bodySnippet += `${indent.repeat(2)}) else (\n`;
+  bodySnippet += `${indent.repeat(3)}!postData ^ accum ^ "\\r\\n\\r\\n" ^ paramValue ^ "\\r\\n"\n`;
+  bodySnippet += `${indent.repeat(2)});\n`;
   bodySnippet += `${indent})\n`;
   bodySnippet += `${indent}else if paramType = "fileName" then (\n`;
   bodySnippet += `${indent.repeat(2)}let (_, filepath) = parameters.(x).(1) in\n`;

--- a/codegens/ocaml-cohttp/test/unit/convert.test.js
+++ b/codegens/ocaml-cohttp/test/unit/convert.test.js
@@ -89,6 +89,45 @@ describe('Ocaml unit tests', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('[| ("name", "json"); ("value", "{\\"hello\\": \\"world\\"}"); ("contentType", "application/json") |]'); // eslint-disable-line max-len
+        expect(snippet).to.contain('postData := if Array.length parameters.(x) == 3 then (');
+        expect(snippet).to.contain('let (_, contentType) = parameters.(x).(2) in');
+        expect(snippet).to.contain('!postData ^ accum ^ "\\r\\n" ^ "Content-Type: " ^ contentType');
+      });
+    });
+
+
     it('should include graphql body in the snippet', function () {
       var request = new sdk.Request({
         'method': 'POST',

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -61,8 +61,10 @@ function parseFormData (body, trim) {
         bodySnippet += '$stringHeader = ' +
           '[System.Net.Http.Headers.ContentDispositionHeaderValue]::new("form-data")\n' +
           `$stringHeader.Name = "${sanitize(data.key, trim)}"\n` +
-          `$StringContent = [System.Net.Http.StringContent]::new("${sanitize(data.value, trim)}")\n` +
-          '$StringContent.Headers.ContentDisposition = $stringHeader\n' +
+          `$stringContent = [System.Net.Http.StringContent]::new("${sanitize(data.value, trim)}")\n` +
+          '$stringContent.Headers.ContentDisposition = $stringHeader\n' +
+          (data.contentType ? '$contentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::new("' +
+            data.contentType + '")\n$stringContent.Headers.ContentType = $contentType\n' : '') +
           '$multipartContent.Add($stringContent)\n\n';
       }
     }

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -422,6 +422,42 @@ describe('Powershell-restmethod converter', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('$contentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::new("application/json")'); // eslint-disable-line max-len
+        expect(snippet).to.contain('$stringContent.Headers.ContentType = $contentType');
+      });
+    });
+
     it('should generate valid snippet for single/double quotes in url', function () {
       var request = new sdk.Request({
         'method': 'GET',
@@ -490,7 +526,7 @@ describe('Powershell-restmethod converter', function () {
         expect(snippet).to.include('$stringHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]' +
         '::new("form-data")');
         expect(snippet).to.include('$stringHeader.Name = "sample_key"');
-        expect(snippet).to.include('$StringContent = [System.Net.Http.StringContent]::new("sample_value")');
+        expect(snippet).to.include('$stringContent = [System.Net.Http.StringContent]::new("sample_value")');
       });
     });
   });

--- a/codegens/python-http.client/lib/util/parseBody.js
+++ b/codegens/python-http.client/lib/util/parseBody.js
@@ -65,7 +65,8 @@ module.exports = function (request, indentation, bodyTrim) {
             requestBody += 'dataList.append(encode(\'--\' + boundary))\n';
             if (data.type !== 'file') {
               requestBody += `dataList.append(encode('Content-Disposition: form-data; name=${sanitize(data.key, 'form-data', true)};'))\n\n`; // eslint-disable-line max-len
-              requestBody += 'dataList.append(encode(\'Content-Type: {}\'.format(\'multipart/form-data\')))\n';
+              requestBody += 'dataList.append(encode(\'Content-Type: {}\'.format(\'' +
+                (data.contentType ? data.contentType : 'text/plain') + '\')))\n';
               requestBody += 'dataList.append(encode(\'\'))\n\n';
               requestBody += `dataList.append(encode("${sanitize(data.value, 'form-data', true)}"))\n`;
             }

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -64,6 +64,42 @@ describe('Python-http.client converter', function () {
         });
       });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('dataList.append(encode(\'Content-Type: {}\'.format(\'application/json\')))'); // eslint-disable-line max-len
+      });
+    });
+
+
     it('should generate snippet with Tab as an indent type', function () {
       convert(request, { indentType: 'Tab', indentCount: 1 }, function (error, snippet) {
         if (error) {

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -99,7 +99,11 @@ function parseFormData (body, mode, trim, indent) {
       }
       else {
         parameter += `${indent.repeat(2)}"value": "${sanitize(data.value, mode, trim)}",\n`;
-        parameter += `${indent.repeat(2)}"type": "text"\n${indent}]`;
+        parameter += `${indent.repeat(2)}"type": "text"`;
+        if (data.contentType) {
+          parameter += `,\n${indent.repeat(2)}"contentType": "${sanitize(data.contentType, mode, trim)}"`;
+        }
+        parameter += `\n${indent}]`;
       }
       parameters.push(parameter);
     }
@@ -114,6 +118,9 @@ function parseFormData (body, mode, trim, indent) {
   bodySnippet += `${indent.repeat(2)}body += "--\\(boundary)\\r\\n"\n`;
   // eslint-disable-next-line no-useless-escape
   bodySnippet += `${indent.repeat(2)}body += "Content-Disposition:form-data; name=\\"\\(paramName)\\"\"\n`;
+  bodySnippet += `${indent.repeat(2)}if param["contentType"] != nil {\n`;
+  bodySnippet += `${indent.repeat(3)}body += "\\r\\nContent-Type: \\(param["contentType"] as! String)"\n`;
+  bodySnippet += `${indent.repeat(2)}}\n`;
   bodySnippet += `${indent.repeat(2)}let paramType = param["type"] as! String\n`;
   bodySnippet += `${indent.repeat(2)}if paramType == "text" {\n`;
   bodySnippet += `${indent.repeat(3)}let paramValue = param["value"] as! String\n`;

--- a/codegens/swift/test/unit/convert.test.js
+++ b/codegens/swift/test/unit/convert.test.js
@@ -30,6 +30,42 @@ describe('Swift Converter', function () {
       });
     });
 
+    it('should add content type if formdata field contains a content-type', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'json',
+              'value': '{"hello": "world"}',
+              'contentType': 'application/json',
+              'type': 'text'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('if param["contentType"] != nil {');
+        expect(snippet).to.contain('body += "\\r\\nContent-Type: \\(param["contentType"] as! String)"');
+      });
+    });
+
     it('should generate snippet with Space as an indent type with default indent count', function () {
       convert(request, { indentType: 'Space' }, function (error, snippet) {
         if (error) {


### PR DESCRIPTION
Fixes https://github.com/postmanlabs/postman-app-support/issues/8736

Support has been added for the following codegens:
* Curl
* Go
* HTTP
* Java - OkHttp
* Java - Unirest
* Libcurl
* Nodejs - Axios
* Nodejs - Native
* Powershell
* Python - http.client
* Swift
* Ocaml

The rest we couldn't support the following because there is no way to add Content-Type for these :
* Javascript - All the codegens use `FormData` api, which does not support content-type for form fields
* Nodejs - Unirest and Request
* All the PHP codegens - they use associative arrays to store formdata. Didn't see how we can add Content-Type
* Ruby - Ruby uses the HTML5 spec instead of ﻿﻿RFC 7578, and it explicitly says that formdata values cannot have Content-Type
* Csharp-Restsharp
* httpie, wget, Python-requests - They don't support formdata at all.