### PR TITLE
Use json.dumps in Python codegens if Content-Type is JSON.

### DIFF
--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -99,7 +99,7 @@ self = module.exports = {
     var snippet = '',
       indentation = '',
       identity = '',
-      url, host, path, query;
+      url, host, path, query, contentType;
 
     if (_.isFunction(options)) {
       callback = options;
@@ -128,7 +128,13 @@ self = module.exports = {
       query = '';
     }
 
+    contentType = request.headers.get('Content-Type');
     snippet += 'import http.client\n';
+
+    // If contentType is json then include the json module for later use
+    if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
+      snippet += 'import json\n';
+    }
     if (request.body && request.body.mode === 'formdata') {
       snippet += 'import mimetypes\n';
       snippet += 'from codecs import encode\n';
@@ -179,7 +185,8 @@ self = module.exports = {
         formdata: formdataArray
       });
     }
-    snippet += parseBody(request.toJSON(), indentation, options.requestBodyTrim);
+
+    snippet += parseBody(request.toJSON(), indentation, options.requestBodyTrim, contentType);
     if (request.body && !request.headers.has('Content-Type')) {
       if (request.body.mode === 'file') {
         request.addHeader({

--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -187,7 +187,7 @@ self = module.exports = {
     }
 
     snippet += parseBody(request.toJSON(), indentation, options.requestBodyTrim, contentType);
-    if (request.body && !request.headers.has('Content-Type')) {
+    if (request.body && !contentType) {
       if (request.body.mode === 'file') {
         request.addHeader({
           key: 'Content-Type',

--- a/codegens/python-http.client/lib/util/parseBody.js
+++ b/codegens/python-http.client/lib/util/parseBody.js
@@ -26,10 +26,11 @@ function replacer (key, value) {
  * The "true", "false" and "null" tokens are not valid in Python
  * so we need to convert them to "True", "False" and "None"
  *
- * @param {Object} jsonBody - JSON object to be converted
+ * @param  {Object} jsonBody - JSON object to be converted
+ * @param  {Number} indentCount - Number of spaces to insert at each indentation level
  */
-function pythonify (jsonBody) {
-  return JSON.stringify(jsonBody, replacer, 2)
+function pythonify (jsonBody, indentCount) {
+  return JSON.stringify(jsonBody, replacer, indentCount)
     .replace(`"${trueToken}"`, 'True')
     .replace(`"${falseToken}"`, 'False')
     .replace(`"${nullToken}"`, 'None');
@@ -62,7 +63,7 @@ module.exports = function (request, indentation, bodyTrim, contentType) {
         if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
           try {
             let jsonBody = JSON.parse(request.body[request.body.mode]);
-            return `payload = json.dumps(${pythonify(jsonBody)})\n`;
+            return `payload = json.dumps(${pythonify(jsonBody, indentation.length)})\n`;
 
           }
           catch (error) {

--- a/codegens/python-http.client/lib/util/parseBody.js
+++ b/codegens/python-http.client/lib/util/parseBody.js
@@ -1,9 +1,9 @@
 var _ = require('../lodash'),
   sanitize = require('./sanitize').sanitize,
   path = require('path'),
-  trueToken = '__PYTHON#%~True__',
-  falseToken = '__PYTHON#%~False__',
-  nullToken = '__PYTHON#%~NULL__';
+  trueToken = '__PYTHON#%0True__',
+  falseToken = '__PYTHON#%0False__',
+  nullToken = '__PYTHON#%0NULL__';
 
 /**
  * Convert true, false and null to Python equivalent True, False and None
@@ -31,9 +31,9 @@ function replacer (key, value) {
  */
 function pythonify (jsonBody, indentCount) {
   return JSON.stringify(jsonBody, replacer, indentCount)
-    .replace(`"${trueToken}"`, 'True')
-    .replace(`"${falseToken}"`, 'False')
-    .replace(`"${nullToken}"`, 'None');
+    .replace(new RegExp(`"${trueToken}"`, 'g'), 'True')
+    .replace(new RegExp(`"${falseToken}"`, 'g'), 'False')
+    .replace(new RegExp(`"${nullToken}"`, 'g'), 'None');
 }
 
 /**

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -99,6 +99,43 @@ describe('Python-http.client converter', function () {
       });
     });
 
+    it('should convert JSON tokens into appropriate python tokens', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'header': [
+          {
+            'key': 'Content-Type',
+            'value': 'application/json',
+            'type': 'text'
+          }
+        ],
+        'body': {
+          'mode': 'raw',
+          'raw': `{
+            "true": true,
+            "false": false,
+            "null": null
+          }`
+        },
+        'url': {
+          'raw': 'https://example.com',
+          'protocol': 'https',
+          'host': [
+            'example',
+            'com'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('"true": True');
+        expect(snippet).to.include('"false": False');
+        expect(snippet).to.include('"null": None');
+      });
+    });
 
     it('should generate snippet with Tab as an indent type', function () {
       convert(request, { indentType: 'Tab', indentCount: 1 }, function (error, snippet) {

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -98,10 +98,11 @@ function replacer (key, value) {
  * The "true", "false" and "null" tokens are not valid in Python
  * so we need to convert them to "True", "False" and "None"
  *
- * @param {Object} jsonBody - JSON object to be converted
+ * @param  {Object} jsonBody - JSON object to be converted
+ * @param  {Number} indentCount - Number of spaces to insert at each indentation level
  */
-function pythonify (jsonBody) {
-  return JSON.stringify(jsonBody, replacer, 2)
+function pythonify (jsonBody, indentCount) {
+  return JSON.stringify(jsonBody, replacer, indentCount)
     .replace(`"${trueToken}"`, 'True')
     .replace(`"${falseToken}"`, 'False')
     .replace(`"${nullToken}"`, 'None');
@@ -135,7 +136,7 @@ module.exports = function (request, indentation, bodyTrim, contentType) {
         if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
           try {
             let jsonBody = JSON.parse(request.body[request.body.mode]);
-            return `payload = json.dumps(${pythonify(jsonBody)})\n`;
+            return `payload = json.dumps(${pythonify(jsonBody, indentation.length)})\n`;
 
           }
           catch (error) {

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -1,8 +1,8 @@
 var _ = require('../lodash'),
   sanitize = require('./sanitize').sanitize,
-  trueToken = '__PYTHON#%~True__',
-  falseToken = '__PYTHON#%~False__',
-  nullToken = '__PYTHON#%~NULL__',
+  trueToken = '__PYTHON#%0True__',
+  falseToken = '__PYTHON#%0False__',
+  nullToken = '__PYTHON#%0NULL__',
   contentTypeHeaderMap = {
     'aac': 'audio/aac',
     'abw': 'application/x-abiword',
@@ -103,9 +103,9 @@ function replacer (key, value) {
  */
 function pythonify (jsonBody, indentCount) {
   return JSON.stringify(jsonBody, replacer, indentCount)
-    .replace(`"${trueToken}"`, 'True')
-    .replace(`"${falseToken}"`, 'False')
-    .replace(`"${nullToken}"`, 'None');
+    .replace(new RegExp(`"${trueToken}"`, 'g'), 'True')
+    .replace(new RegExp(`"${falseToken}"`, 'g'), 'False')
+    .replace(new RegExp(`"${nullToken}"`, 'g'), 'None');
 }
 
 /**

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -1,5 +1,8 @@
 var _ = require('../lodash'),
   sanitize = require('./sanitize').sanitize,
+  trueToken = '__PYTHON#%~True__',
+  falseToken = '__PYTHON#%~False__',
+  nullToken = '__PYTHON#%~NULL__',
   contentTypeHeaderMap = {
     'aac': 'audio/aac',
     'abw': 'application/x-abiword',
@@ -75,14 +78,45 @@ var _ = require('../lodash'),
   };
 
 /**
+ * Convert true, false and null to Python equivalent True, False and None
+ *
+ * @param {String} key
+ * @param {Object} value
+ */
+function replacer (key, value) {
+  if (typeof value === 'boolean') {
+    return value ? trueToken : falseToken;
+  }
+  else if (value === null) {
+    return nullToken;
+  }
+  return value;
+}
+
+/**
+ * Convert JSON into a valid Python dict
+ * The "true", "false" and "null" tokens are not valid in Python
+ * so we need to convert them to "True", "False" and "None"
+ *
+ * @param {Object} jsonBody - JSON object to be converted
+ */
+function pythonify (jsonBody) {
+  return JSON.stringify(jsonBody, replacer, 2)
+    .replace(`"${trueToken}"`, 'True')
+    .replace(`"${falseToken}"`, 'False')
+    .replace(`"${nullToken}"`, 'None');
+}
+
+/**
  * Used to parse the body of the postman SDK-request and return in the desired format
  *
  * @param  {Object} request - postman SDK-request object
  * @param  {String} indentation - used for indenting snippet's structure
  * @param  {Boolean} bodyTrim - whether to trim request body fields
+ * @param  {String} contentType - content-type of body
  * @returns {String} - request body
  */
-module.exports = function (request, indentation, bodyTrim) {
+module.exports = function (request, indentation, bodyTrim, contentType) {
   // used to check whether body is present in the request or not
   if (request.body) {
     var requestBody = '',
@@ -92,14 +126,25 @@ module.exports = function (request, indentation, bodyTrim) {
 
     switch (request.body.mode) {
       case 'raw':
-        if (!_.isEmpty(request.body[request.body.mode])) {
-          requestBody += `payload=${sanitize(request.body[request.body.mode],
-            request.body.mode, bodyTrim)}\n`;
+        if (_.isEmpty(request.body[request.body.mode])) {
+          requestBody = 'payload = {}\n';
         }
-        else {
-          requestBody = 'payload={}\n';
+        // Match any application type whose underlying structure is json
+        // For example application/vnd.api+json
+        // All of them have +json as suffix
+        if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
+          try {
+            let jsonBody = JSON.parse(request.body[request.body.mode]);
+            return `payload = json.dumps(${pythonify(jsonBody)})\n`;
+
+          }
+          catch (error) {
+            // Do nothing
+          }
         }
-        return requestBody;
+        return `payload = ${sanitize(request.body[request.body.mode],
+          request.body.mode, bodyTrim)}\n`;
+
       case 'graphql':
         // eslint-disable-next-line no-case-declarations
         let query = request.body[request.body.mode].query,

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -63,6 +63,44 @@ describe('Python- Requests converter', function () {
     });
   });
 
+  it('should convert JSON tokens into appropriate python tokens', function () {
+    var request = new sdk.Request({
+      'method': 'POST',
+      'header': [
+        {
+          'key': 'Content-Type',
+          'value': 'application/json',
+          'type': 'text'
+        }
+      ],
+      'body': {
+        'mode': 'raw',
+        'raw': `{
+          "true": true,
+          "false": false,
+          "null": null
+        }`
+      },
+      'url': {
+        'raw': 'https://example.com',
+        'protocol': 'https',
+        'host': [
+          'example',
+          'com'
+        ]
+      }
+    });
+    convert(request, {}, function (error, snippet) {
+      if (error) {
+        expect.fail(null, null, error);
+      }
+      expect(snippet).to.be.a('string');
+      expect(snippet).to.include('"true": True');
+      expect(snippet).to.include('"false": False');
+      expect(snippet).to.include('"null": None');
+    });
+  });
+
   it('should generate snippets for no files in form data', function () {
     var request = new sdk.Request({
       'method': 'POST',


### PR DESCRIPTION
Fixes #426 
Before:
```
payload="{\n    \"Hello\": \"world\",\n    \"boolean\": true,\n    \"array\": [1,2,3]\n}"
```
After:
```
payload = json.dumps({
  "Hello": "world",
  "boolean": True,
  "array": [
    1,
    2,
    3
  ]
})
```