### PR TITLE
Ignore always changing headers returned by mockbin

### DIFF
--- a/test/codegen/newman/newmanTestUtil.js
+++ b/test/codegen/newman/newmanTestUtil.js
@@ -126,7 +126,9 @@ function runSnippet (testConfig, snippets, collectionName) {
             'if-none-match',
             'referer',
             'x-amzn-trace-id',
-            'transfer-encoding'
+            'transfer-encoding',
+            'cf-connecting-ip',
+            'cf-request-id'
           ];
         if (result[0]) {
           propertiesTodelete.forEach(function (property) {


### PR DESCRIPTION
`cf-connecting-ip` is can be different in the CI for each request, while `cf-request-id`is always different. This is causing one of the newman tests to fail. Ignoring these headers fixes this.