### PR TITLE
Add proper formatting of JSON in Dart and C#

### DIFF
--- a/codegens/csharp-restsharp/lib/parseRequest.js
+++ b/codegens/csharp-restsharp/lib/parseRequest.js
@@ -78,8 +78,12 @@ function parseBody (request, trimFields) {
       case 'formdata':
         return parseFormData(requestBody, trimFields);
       case 'raw':
-        return `request.AddParameter("${parseContentType(request)}", ` +
-                    `${JSON.stringify(requestBody[requestBody.mode])},  ParameterType.RequestBody);\n`;
+        return `var body = ${requestBody[requestBody.mode]
+          .split('\n')
+          .map((line) => { return '@"' + line.replace(/"/g, '""') + '"'; })
+          .join(' + "\\n" +\n')};\n` +
+          `request.AddParameter("${parseContentType(request)}", ` +
+          'body,  ParameterType.RequestBody);\n';
       case 'graphql':
         return parseGraphQL(requestBody, trimFields);
         /* istanbul ignore next */

--- a/codegens/dart-http/lib/index.js
+++ b/codegens/dart-http/lib/index.js
@@ -31,12 +31,13 @@ function parseUrlEncoded (body, indent, trim) {
  * @param {Object} body Raw body data
  * @param {Boolean} trim indicates whether to trim string or not
  * @param {String} contentType the content-type of request body
+ * @param {Integer} indentCount the number of space to use
  */
-function parseRawBody (body, trim, contentType) {
+function parseRawBody (body, trim, contentType, indentCount) {
   if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
     try {
       let jsonBody = JSON.parse(body);
-      return `request.body = json.encode(${JSON.stringify(jsonBody, null, 4)});`;
+      return `request.body = json.encode(${JSON.stringify(jsonBody, null, indentCount)});`;
 
     }
     catch (error) {
@@ -129,7 +130,7 @@ function parseBody (body, indent, trim, contentType) {
       case 'urlencoded':
         return parseUrlEncoded(body.urlencoded, indent, trim);
       case 'raw':
-        return parseRawBody(body.raw, trim, contentType);
+        return parseRawBody(body.raw, trim, contentType, indent.length);
       case 'formdata':
         return parseFormData(body.formdata, indent, trim);
       case 'graphql':


### PR DESCRIPTION
Fixes #459 
C#:
```
using RestSharp;
namespace HelloWorldApplication {
  class HelloWorld {
    static void Main(string[] args) {
      var client = new RestClient("http://example.com");
      client.Timeout = -1;
      var request = new RestRequest(Method.GET);
      request.AddHeader("Content-Type", "application/json");
      var body = @"{" + "\n" +
      @"    ""hello"": ""world""," + "\n" +
      @"    ""this"": true," + "\n" +
      @"    ""call"": [1,2,3,null]" + "\n" +
      @"}";
      request.AddParameter("application/json", body,  ParameterType.RequestBody);
      IRestResponse response = client.Execute(request);
      Console.WriteLine(response.Content);
    }
  }
}
```

Dart:
```
import 'dart:convert';
import 'package:http/http.dart' as http;

void main() async {
  var headers = {
    'Content-Type': 'application/json'
  };
  var request = http.Request('GET', Uri.parse('http://example.com'));
  request.body = json.encode({
      "hello": "world",
      "this": true,
      "call": [
          1,
          2,
          3,
          null
      ]
  });
  request.headers.addAll(headers);
  
  http.StreamedResponse response = await request.send();
  
  if (response.statusCode == 200) {
    print(await response.stream.bytesToString());
  }
  else {
    print(response.reasonPhrase);
  }
  
}
```