### PR TITLE
Fix documentation for timeout setting in curl codegen

### DIFF
--- a/codegens/curl/README.md
+++ b/codegens/curl/README.md
@@ -18,7 +18,7 @@ Convert function takes three parameters
     * `indentCount` - The number of indentation characters to add per code level
     * `trimRequestBody` - Trim request body fields
     * `followRedirect` - Boolean denoting whether to redirect a request
-    * `requestTimeout` - Integer denoting time after which the request will bail out in milli-seconds
+    * `requestTimeout` - Integer denoting time after which the request will bail out in seconds
     * `multiLine` - Boolean denoting whether to output code snippet with multi line breaks
     * `longFormat` - Boolean denoting whether to use longform cURL options in snippet
     * `quoteType` - String denoting the quote type to use (single or double) for URL

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -226,7 +226,7 @@ self = module.exports = {
         id: 'requestTimeout',
         type: 'positiveInteger',
         default: 0,
-        description: 'Set number of milliseconds the request should wait for a response before ' +
+        description: 'Set number of seconds the request should wait for a response before ' +
           'timing out (use 0 for infinity)'
       },
       {


### PR DESCRIPTION
Change doc to says `seconds` instead of `milliseconds` for `--max-timeout` option in `curl`.
Fixes #486 