### PR TITLE
Allow GET method to have a body in java-okhttp if present in input request.

### DIFF
--- a/codegens/java-okhttp/lib/okhttp.js
+++ b/codegens/java-okhttp/lib/okhttp.js
@@ -6,7 +6,7 @@ var _ = require('./lodash'),
   sanitizeOptions = require('./util').sanitizeOptions;
 
 //  Since Java OkHttp requires to add extralines of code to handle methods with body
-const METHODS_WITHOUT_BODY = ['GET', 'HEAD', 'COPY', 'UNLOCK', 'UNLINK', 'PURGE', 'LINK', 'VIEW'];
+const METHODS_WITHOUT_BODY = ['HEAD', 'COPY', 'UNLOCK', 'UNLINK', 'PURGE', 'LINK', 'VIEW'];
 
 /**
  * returns snippet of java okhttp by parsing data from Postman-SDK request object


### PR DESCRIPTION
Fixes #502 