### PR TITLE
Add Restsharp version to download in ci-requirements

### DIFF
--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -24,7 +24,7 @@ pushd ./codegens/csharp-restsharp &>/dev/null;
   sudo apt-get install dotnet-sdk-2.2
   dotnet new console -o testProject
   pushd ./testProject &>/dev/null;
-  dotnet add package RestSharp
+  dotnet add package RestSharp --version 106.15.0
   popd &>/dev/null;
 popd &>/dev/null;
 


### PR DESCRIPTION
Fixes the issue of CI pipeline breaking