### PR TITLE
Add warning comments before misleading code in JS-xhr

### DIFF
--- a/codegens/js-xhr/lib/index.js
+++ b/codegens/js-xhr/lib/index.js
@@ -150,6 +150,9 @@ function parseHeaders (headers) {
   if (!_.isEmpty(headers)) {
     headers = _.reject(headers, 'disabled');
     _.forEach(headers, function (header) {
+      if (_.capitalize(header.key) === 'Cookie') {
+        headerSnippet += '// WARNING: Cookies will be stripped away by the browser before sending the request.\n';
+      }
       headerSnippet += `xhr.setRequestHeader("${sanitize(header.key, true)}", "${sanitize(header.value)}");\n`;
     });
   }
@@ -263,6 +266,9 @@ function convert (request, options, callback) {
   bodySnippet = request.body && !_.isEmpty(request.body.toJSON()) ? parseBody(request.body.toJSON(), trim,
     indent, request.headers.get('Content-Type')) : '';
 
+  if (_.includes(['Get', 'Post'], _.capitalize(request.method))) {
+    codeSnippet += `// WARNING: For ${request.method} requests, body is set to null by browsers.\n`;
+  }
   codeSnippet += bodySnippet + '\n';
 
   codeSnippet += 'var xhr = new XMLHttpRequest();\nxhr.withCredentials = true;\n\n';


### PR DESCRIPTION
If a user tries send a GET request with a body or with the `Cookie` header set, the add a comment warning them that browser will strip them away before sending the request. For example:
```javascript
// WARNING: For GET requests, body is set to null by browsers.
var data = JSON.stringify({
  'hello': 'world'
});

var xhr = new XMLHttpRequest();
xhr.withCredentials = true;

xhr.addEventListener("readystatechange", function() {
  if(this.readyState === 4) {
    console.log(this.responseText);
  }
});

xhr.open("GET", "https://postman-echo.com/get");
// WARNING: Cookies will be stripped away by the browser before sending the request.
xhr.setRequestHeader("Cookie", "cookie");
xhr.setRequestHeader("Content-Type", "application/json");

xhr.send(data);
```