### PR TITLE
[README.md] Added links to request object defenition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Manage all of your organization's APIs in Postman, with the industry's most com
 
 # postman-code-generators [![Build Status](https://travis-ci.com/postmanlabs/postman-code-generators.svg?branch=master)](https://travis-ci.com/postmanlabs/postman-code-generators)
 
-This module converts a [Postman SDK](https://github.com/postmanlabs/postman-collection) Request Object into a code snippet of chosen language.
+This module converts a [Postman SDK](https://github.com/postmanlabs/postman-collection) Request [Object](https://github.com/postmanlabs/postman-collection/blob/42c7416080e5f8a0ab76101e979afbd700304665/types/index.d.ts#L1901) into a code snippet of chosen language.
 
 Every code generator has two identifiers: `language` and `variant`.
 * `language` of a code generator is the programming language in which the code snippet is generated.
@@ -160,7 +160,7 @@ var codegen = require('postman-code-generators'), // require postman-code-genera
 This function takes in five parameters and returns a callback with error and generated code snippet
 * `language` - lang key from the language list returned from getLanguageList function
 * `variant` - variant key provided by getLanguageList function
-* `request` - [Postman-SDK](https://github.com/postmanlabs/postman-collection) Request Object
+* `request` - [Postman-SDK](https://github.com/postmanlabs/postman-collection) Request [Object](https://github.com/postmanlabs/postman-collection/blob/42c7416080e5f8a0ab76101e979afbd700304665/types/index.d.ts#L1901)
 * `options` - Options that can be used to configure generated code snippet. Defaults will be used for the unspecified attributes  
 * `callback` - callback function with first parameter as error and second parameter as string for code snippet
 


### PR DESCRIPTION
README mentions request object from [Postman SDK](https://github.com/postmanlabs/postman-collection) twice, but there were no direct links to it