### PR TITLE
Do not add HTTP method explicitly in curl when not required

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -244,7 +244,7 @@ self = module.exports = {
         id: 'followOriginalHttpMethod',
         type: 'boolean',
         default: false,
-        description: 'Use the original HTTP method when following redirects'
+        description: 'Redirect with the original HTTP method instead of the default behavior of redirecting with GET'
       },
       {
         name: 'Trim request body fields',

--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -3,6 +3,7 @@ var sanitize = require('./util').sanitize,
   getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   addFormParam = require('./util').addFormParam,
   form = require('./util').form,
+  shouldAddHttpMethod = require('./util').shouldAddHttpMethod,
   _ = require('./lodash'),
   self;
 
@@ -44,12 +45,14 @@ self = module.exports = {
     else {
       indent = ' ';
     }
+
     if (request.method === 'HEAD') {
-      snippet += ` ${form('-I', format)} ${quoteType + url + quoteType}`;
+      snippet += ` ${form('-I', format)}`;
     }
-    else {
-      snippet += ` ${form('-X', format)} ${request.method} ${quoteType + url + quoteType}`;
+    if (shouldAddHttpMethod(request, options)) {
+      snippet += ` ${form('-X', format)} ${request.method}`;
     }
+    snippet += ` ${quoteType + url + quoteType}`;
 
     if (request.body && !request.headers.has('Content-Type')) {
       if (request.body.mode === 'file') {
@@ -235,6 +238,13 @@ self = module.exports = {
         type: 'boolean',
         default: true,
         description: 'Automatically follow HTTP redirects'
+      },
+      {
+        name: 'Follow original HTTP method',
+        id: 'followOriginalHttpMethod',
+        type: 'boolean',
+        default: false,
+        description: 'Use the original HTTP method when following redirects'
       },
       {
         name: 'Trim request body fields',

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -1,3 +1,5 @@
+const _ = require('./lodash');
+
 var self = module.exports = {
   /**
      * sanitizes input string by handling escape characters eg: converts '''' to '\'\'', (" to \"  and \ to \\ )
@@ -198,6 +200,78 @@ var self = module.exports = {
         disabled: disabled,
         contentType: contentType
       });
+    }
+  },
+
+  /**
+   * @param {Object} body
+   * @returns {boolean}
+   *
+   * Determines if a request body is actually empty.
+   * This is needed because body.isEmpty() returns false for formdata
+   * and urlencoded when they contain only disabled params which will not
+   * be a part of the curl request.
+   */
+  isBodyEmpty (body) {
+    if (!body) {
+      return true;
+    }
+
+    if (body.isEmpty()) {
+      return true;
+    }
+
+    if (body.mode === 'formdata' || body.mode === 'urlencoded') {
+      let memberCount = 0;
+      body[body.mode].members && body[body.mode].members.forEach((param) => {
+        if (!param.disabled) {
+          memberCount += 1;
+        }
+      });
+
+      return memberCount === 0;
+    }
+
+    return false;
+  },
+
+  /**
+   * Decide whether we should add the HTTP method explicitly to the cURL command.
+   *
+   * @param {Object} request
+   * @param {Object} options
+   *
+   * @returns {Boolean}
+   */
+  shouldAddHttpMethod: function (request, options) {
+    const followOriginalHttpMethod =
+      _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', options.followOriginalHttpMethod),
+      disableBodyPruning = _.get(request, 'protocolProfileBehavior.disableBodyPruning', true),
+      isBodyEmpty = self.isBodyEmpty(request.body);
+
+    if (options.followRedirect && followOriginalHttpMethod) {
+      return true;
+    }
+
+    switch (request.method) {
+      case 'HEAD':
+        return false;
+      case 'GET':
+        // disableBodyPruning will generally not be present in the request
+        // the only time it will be present, its value will be _false_
+        // i.e. the user wants to prune the request body despite it being present
+        if (!isBodyEmpty && disableBodyPruning) {
+          return true;
+        }
+
+        return false;
+      case 'POST':
+        return isBodyEmpty;
+      case 'DELETE':
+      case 'PUT':
+      case 'PATCH':
+      default:
+        return true;
     }
   }
 };

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -244,12 +244,13 @@ var self = module.exports = {
    * @returns {Boolean}
    */
   shouldAddHttpMethod: function (request, options) {
-    const followOriginalHttpMethod =
-      options.followOriginalHttpMethod || _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', false),
+    const followRedirect = _.get(request, 'protocolProfileBehavior.followRedirects', options.followRedirect),
+      followOriginalHttpMethod =
+      _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', options.followOriginalHttpMethod),
       disableBodyPruning = _.get(request, 'protocolProfileBehavior.disableBodyPruning', true),
       isBodyEmpty = self.isBodyEmpty(request.body);
 
-    if (options.followRedirect && followOriginalHttpMethod) {
+    if (followRedirect && followOriginalHttpMethod) {
       return true;
     }
 

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -223,7 +223,7 @@ var self = module.exports = {
 
     if (body.mode === 'formdata' || body.mode === 'urlencoded') {
       let memberCount = 0;
-      body[body.mode].members && body[body.mode].members.forEach((param) => {
+      body[body.mode] && body[body.mode].members && body[body.mode].members.forEach((param) => {
         if (!param.disabled) {
           memberCount += 1;
         }
@@ -245,7 +245,7 @@ var self = module.exports = {
    */
   shouldAddHttpMethod: function (request, options) {
     const followOriginalHttpMethod =
-      _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', options.followOriginalHttpMethod),
+      options.followOriginalHttpMethod || _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', false),
       disableBodyPruning = _.get(request, 'protocolProfileBehavior.disableBodyPruning', true),
       isBodyEmpty = self.isBodyEmpty(request.body);
 

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -767,16 +767,15 @@ describe('curl convert function', function () {
       });
     });
 
-    it('should add --request parameter when options ' +
-      'followRedirect and followOriginalHttpMethod are true', function () {
-      const methods = ['GET', 'HEAD', 'DELETE', 'PUT', 'POST', 'PATCH'],
-        request = new sdk.Request({
+    describe('followRedirect and followOriginalHttpMethod', function () {
+      it('should add --request parameter when passed true via options', function () {
+        const request = new sdk.Request({
           'method': 'POST',
           'header': [],
           'body': {
             'mode': 'graphql',
             'graphql': {
-              'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+                'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
               'variables': '{\n\t"variable_key": "variable_value"\n}'
             }
           },
@@ -793,21 +792,125 @@ describe('curl convert function', function () {
           }
         });
 
-      // this needs to be done here because protocolProfileBehavior is not in collections SDK
-      request.protocolProfileBehavior = {
-        followOriginalHttpMethod: true
-      };
-
-      for (let method of methods) {
-        request.method = method;
-        convert(request, { followRedirect: true }, function (error, snippet) {
+        convert(request, { followRedirect: true, followOriginalHttpMethod: true }, function (error, snippet) {
           if (error) {
             expect.fail(null, null, error);
           }
           expect(snippet).to.be.a('string');
-          expect(snippet).to.include(`--request ${method}`);
+          expect(snippet).to.include('--request POST');
         });
-      }
+      });
+
+      it('should not add --request parameter when passed false via options', function () {
+        const request = new sdk.Request({
+          'method': 'POST',
+          'header': [],
+          'body': {
+            'mode': 'graphql',
+            'graphql': {
+                'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+              'variables': '{\n\t"variable_key": "variable_value"\n}'
+            }
+          },
+          'url': {
+            'raw': 'https://postman-echo.com/post',
+            'protocol': 'https',
+            'host': [
+              'postman-echo',
+              'com'
+            ],
+            'path': [
+              'post'
+            ]
+          }
+        });
+
+        convert(request, { followRedirect: false, followOriginalHttpMethod: false }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet).to.not.include('--request POST');
+        });
+      });
+
+      it('should add --request parameter when passed false via options but true in request settings', function () {
+        const request = new sdk.Request({
+          'method': 'POST',
+          'header': [],
+          'body': {
+            'mode': 'graphql',
+            'graphql': {
+                'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+              'variables': '{\n\t"variable_key": "variable_value"\n}'
+            }
+          },
+          'url': {
+            'raw': 'https://postman-echo.com/post',
+            'protocol': 'https',
+            'host': [
+              'postman-echo',
+              'com'
+            ],
+            'path': [
+              'post'
+            ]
+          }
+        });
+
+        // this needs to be done here because protocolProfileBehavior is not in collections SDK
+        request.protocolProfileBehavior = {
+          followRedirects: true,
+          followOriginalHttpMethod: true
+        };
+
+        convert(request, { followRedirect: false, followOriginalHttpMethod: false }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet).to.include('--request POST');
+        });
+      });
+
+      it('should not add --request parameter when passed true via options but false in request settings', function () {
+        const request = new sdk.Request({
+          'method': 'POST',
+          'header': [],
+          'body': {
+            'mode': 'graphql',
+            'graphql': {
+                'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+              'variables': '{\n\t"variable_key": "variable_value"\n}'
+            }
+          },
+          'url': {
+            'raw': 'https://postman-echo.com/post',
+            'protocol': 'https',
+            'host': [
+              'postman-echo',
+              'com'
+            ],
+            'path': [
+              'post'
+            ]
+          }
+        });
+
+        // this needs to be done here because protocolProfileBehavior is not in collections SDK
+        request.protocolProfileBehavior = {
+          followRedirects: false,
+          followOriginalHttpMethod: false
+        };
+
+        convert(request, { followRedirect: true, followOriginalHttpMethod: true }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet).to.not.include('--request POST');
+        });
+      });
     });
   });
 });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -277,7 +277,7 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include("GET 'https://google.com'"); // eslint-disable-line quotes
+        expect(snippet).to.include("'https://google.com'"); // eslint-disable-line quotes
       });
     });
 
@@ -634,6 +634,180 @@ describe('curl convert function', function () {
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
+    });
+
+    it('should not add --request parameter in POST request if body is present', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'body': {
+          'mode': 'graphql',
+          'graphql': {
+            'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+            'variables': '{\n\t"variable_key": "variable_value"\n}'
+          }
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/post',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, { followRedirect: true }, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.not.include('--request POST');
+      });
+    });
+
+    it('should add --request parameter in POST request if body is not present', function () {
+      var request = new sdk.Request({
+        'method': 'POST',
+        'header': [],
+        'url': {
+          'raw': 'https://postman-echo.com/post',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, { followRedirect: true }, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('--request POST');
+      });
+    });
+
+    it('should add --request parameter in GET request if body is present', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'body': {
+          'mode': 'graphql',
+          'graphql': {
+            'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+            'variables': '{\n\t"variable_key": "variable_value"\n}'
+          }
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/get',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ]
+        }
+      });
+
+      convert(request, { followRedirect: true }, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('--request GET');
+      });
+    });
+
+    it('should not add --request parameter in GET request if body is present ' +
+      'but disableBodyPruning is false', function () {
+      const request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'body': {
+          'mode': 'graphql',
+          'graphql': {
+            'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+            'variables': '{\n\t"variable_key": "variable_value"\n}'
+          }
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/get',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'get'
+          ]
+        }
+      });
+
+      // this needs to be done here because protocolProfileBehavior is not in collections SDK
+      request.protocolProfileBehavior = {
+        disableBodyPruning: false
+      };
+
+      convert(request, { followRedirect: true }, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.not.include('--request GET');
+      });
+    });
+
+    it('should add --request parameter when options ' +
+      'followRedirect and followOriginalHttpMethod are true', function () {
+      const methods = ['GET', 'HEAD', 'DELETE', 'PUT', 'POST', 'PATCH'],
+        request = new sdk.Request({
+          'method': 'POST',
+          'header': [],
+          'body': {
+            'mode': 'graphql',
+            'graphql': {
+              'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+              'variables': '{\n\t"variable_key": "variable_value"\n}'
+            }
+          },
+          'url': {
+            'raw': 'https://postman-echo.com/post',
+            'protocol': 'https',
+            'host': [
+              'postman-echo',
+              'com'
+            ],
+            'path': [
+              'post'
+            ]
+          }
+        });
+
+      // this needs to be done here because protocolProfileBehavior is not in collections SDK
+      request.protocolProfileBehavior = {
+        followOriginalHttpMethod: true
+      };
+
+      for (let method of methods) {
+        request.method = method;
+        convert(request, { followRedirect: true }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet).to.include(`--request ${method}`);
+        });
+      }
     });
   });
 });

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -61,7 +61,7 @@ const expectedOptions = {
       name: 'Follow original HTTP method',
       type: 'boolean',
       default: false,
-      description: 'Use the original HTTP method when following redirects'
+      description: 'Redirect with the original HTTP method instead of the default behavior of redirecting with GET'
     },
     trimRequestBody: {
       name: 'Trim request body fields',

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -57,6 +57,12 @@ const expectedOptions = {
       default: true,
       description: 'Automatically follow HTTP redirects'
     },
+    followOriginalHttpMethod: {
+      name: 'Follow original HTTP method',
+      type: 'boolean',
+      default: false,
+      description: 'Use the original HTTP method when following redirects'
+    },
     trimRequestBody: {
       name: 'Trim request body fields',
       type: 'boolean',
@@ -95,6 +101,7 @@ const expectedOptions = {
     'silent',
     'includeBoilerplate',
     'followRedirect',
+    'followOriginalHttpMethod',
     'lineContinuationCharacter',
     'protocol',
     'useMimeType',


### PR DESCRIPTION
- For `HEAD`, do not add `--request`
- For `GET` only add if it has a request body and the request has body pruning is not enabled
- For `POST`, only add if there is no request body
- Add it explicitly in cases where the user has selected to follow redirects and also retain the original HTTP method while doing it
- Introduced a new option, `followOriginalHttpMethod` with the default value `false`
- We're trying to make the experience for users better by also honouring request settings as it is sometimes frustrating to tweak snippet settings in addition to request settings.
  - `followOriginalHttpMethod` is also an option in request in Postman. To better enable integration with the request editor, we honour the value if present in request and fallback to options if not present.
  - 'followRedirect` also honours to request level `followRedirects` option is present, falling back to options if not present.

Fixes https://github.com/postmanlabs/postman-app-support/issues/10581.

More here: https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/