### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v1.4.0 (February 6, 2023)
+* Add support for C# HttpClient Codegen
+* Use short options in CURL as long as possible (9511)[https://github.com/postmanlabs/postman-app-support/issues/9511]
+* Do not add HTTP method explicitly in CURL when not required (10581)[https://github.com/postmanlabs/postman-app-support/issues/10581]
+* Remove usage of semaphore from Swift Codegen (10053)[https://github.com/postmanlabs/postman-app-support/issues/10053]
+
 v1.3.0 (December 16, 2022)
 * Update C# restsharp codegen to support (107)[https://restsharp.dev/v107/]
 * Fixes an issue where HTTP code snippet was generating wrong boundaries (11084)[https://github.com/postmanlabs/postman-app-support/issues/11084]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-code-generators",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-code-generators",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Generates code snippets for a postman collection",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* Add support for C# HttpClient Codegen
* Use short options in CURL as long as possible postmanlabs/postman-app-support#9511
* Do not add HTTP method explicitly in CURL when not required postmanlabs/postman-app-support#10581
* Remove usage of semaphore from Swift Codegen postmanlabs/postman-app-support#10053