### PR TITLE
Escape backslash character in raw bodies for curl codegen

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -141,7 +141,7 @@ self = module.exports = {
               isAsperandPresent = _.includes(rawBody, '@'),
               // Use the long option if `@` is present in the request body otherwise follow user setting
               optionName = isAsperandPresent ? '--data-raw' : form('-d', format);
-            snippet += indent + `${optionName} ${quoteType}${sanitize(rawBody, trim, quoteType)}${quoteType}`;
+            snippet += indent + `${optionName} ${quoteType}${sanitize(rawBody, trim, quoteType, true)}${quoteType}`;
             break;
           }
 

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -65,7 +65,6 @@ describe('curl convert function', function () {
           expect.fail(null, null, error);
         }
 
-        console.log(snippet);
         expect(snippet).to.contain('{ "foo": "\\\\" }');
       });
     });

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -34,6 +34,42 @@ describe('curl convert function', function () {
       });
     });
 
+    it('should escape backslash in raw bodies', function () {
+      request = new sdk.Request({
+        'method': 'POST',
+        'header': [
+          {
+            'key': 'Content-Type',
+            'value': 'application/json'
+          }
+        ],
+        'body': {
+          'mode': 'raw',
+          'raw': '{ "foo": "\\" }'
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/post',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+
+        console.log(snippet);
+        expect(snippet).to.contain('{ "foo": "\\\\" }');
+      });
+    });
+
     it('should return snippet with url in single quote(\')', function () {
       request = new sdk.Request({
         'method': 'POST',


### PR DESCRIPTION
Make use of  the `backSlash: true` argument in `sanitize` function for Raw bodies.

Fixes postmanlabs/postman-app-support#11049