### PR TITLE
cURL codegen should work when request has a protocolProfileBehavior with null value

### DIFF
--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -297,7 +297,8 @@ var self = module.exports = {
       disableBodyPruning = true,
       isBodyEmpty = self.isBodyEmpty(request.body);
 
-    if (_.has(request, 'protocolProfileBehavior') && request.protocolProfileBehavior !== null) {
+    // eslint-disable-next-line lodash/prefer-is-nil
+    if (request.protocolProfileBehavior !== null && request.protocolProfileBehavior !== undefined) {
       followRedirect = _.get(request, 'protocolProfileBehavior.followRedirects', followRedirect);
       followOriginalHttpMethod =
         _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', followOriginalHttpMethod);

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -292,11 +292,17 @@ var self = module.exports = {
    * @returns {Boolean}
    */
   shouldAddHttpMethod: function (request, options) {
-    const followRedirect = _.get(request, 'protocolProfileBehavior.followRedirects', options.followRedirect),
-      followOriginalHttpMethod =
-      _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', options.followOriginalHttpMethod),
-      disableBodyPruning = _.get(request, 'protocolProfileBehavior.disableBodyPruning', true),
+    let followRedirect = options.followRedirect,
+      followOriginalHttpMethod = options.followOriginalHttpMethod,
+      disableBodyPruning = true,
       isBodyEmpty = self.isBodyEmpty(request.body);
+
+    if (_.has(request, 'protocolProfileBehavior') && request.protocolProfileBehavior !== null) {
+      followRedirect = _.get(request, 'protocolProfileBehavior.followRedirects', followRedirect);
+      followOriginalHttpMethod =
+        _.get(request, 'protocolProfileBehavior.followOriginalHttpMethod', followOriginalHttpMethod);
+      disableBodyPruning = _.get(request, 'protocolProfileBehavior.disableBodyPruning', true);
+    }
 
     if (followRedirect && followOriginalHttpMethod) {
       return true;

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -976,6 +976,42 @@ describe('curl convert function', function () {
           expect(snippet).to.not.include('--request POST');
         });
       });
+
+      it('should work when protocolProfileBehavior is null in request settings', function () {
+        const request = new sdk.Request({
+          'method': 'POST',
+          'header': [],
+          'body': {
+            'mode': 'graphql',
+            'graphql': {
+                'query': '{\n  findScenes(\n    filter: {per_page: 0}\n    scene_filter: {is_missing: "performers"}){\n    count\n    scenes {\n      id\n      title\n      path\n    }\n  }\n}', // eslint-disable-line
+              'variables': '{\n\t"variable_key": "variable_value"\n}'
+            }
+          },
+          'url': {
+            'raw': 'https://postman-echo.com/post',
+            'protocol': 'https',
+            'host': [
+              'postman-echo',
+              'com'
+            ],
+            'path': [
+              'post'
+            ]
+          }
+        });
+
+        // this needs to be done here because protocolProfileBehavior is not in collections SDK
+        request.protocolProfileBehavior = null;
+
+        convert(request, { followRedirect: true, followOriginalHttpMethod: true }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.be.a('string');
+          expect(snippet).to.include('--request POST');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
We use a custom lodash version that doesn't have the latest fixes. So it fails when the property we compare is `null` in the `_.get` chain.