### PR TITLE
Add long form option for -g

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -36,7 +36,7 @@ self = module.exports = {
       snippet += ` ${form('-m', format)} ${timeout}`;
     }
     if ((url.match(/[{[}\]]/g) || []).length > 0) {
-      snippet += ' -g';
+      snippet += ` ${form('-g', format)}`;
     }
     if (multiLine) {
       indent = options.indentType === 'Tab' ? '\t' : ' ';

--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -57,6 +57,8 @@ var self = module.exports = {
           return '--data';
         case '-F':
           return '--form';
+        case '-g':
+          return '--globoff';
         default:
           return '';
       }

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -265,7 +265,7 @@ describe('curl convert function', function () {
         ']world',
         'world}'
       ].forEach(function (value) {
-        request = new sdk.Request({
+        const request = new sdk.Request({
           'method': 'GET',
           'url': {
             'raw': `http://example.com?hello=${value}`,
@@ -287,6 +287,12 @@ describe('curl convert function', function () {
             expect.fail(null, null, error);
           }
           expect(snippet).to.include('-g');
+        });
+        convert(request, { longFormat: true }, function (error, snippet) {
+          if (error) {
+            expect.fail(null, null, error);
+          }
+          expect(snippet).to.include('--globoff');
         });
       });
     });


### PR DESCRIPTION
`-g` option was missing the long-form option equivalent. This PR adds the `--globoff` counterpart.

[Documentation](https://curl.se/docs/manpage.html) for this option:

> -g, --globoff
> This option switches off the "URL globbing parser". When you set this option, you can specify URLs that contain the letters {}[] without having curl itself interpret them. Note that these letters are not normal legal URL contents but they should be encoded according to the URI standard. 