### PR TITLE
Use multiline quotes in Powershell to simplify generated code

### DIFF
--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -82,7 +82,7 @@ function parseFormData (body, trim) {
  * @param {boolean} trim trim body option
  */
 function parseRawBody (body, trim) {
-  return `$body = @"${sanitize(body.toString(), trim)}\n"@\n`;
+  return `$body = @"${sanitize(body.toString(), trim, false)}\n"@\n`;
 }
 
 /**

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -82,7 +82,7 @@ function parseFormData (body, trim) {
  * @param {boolean} trim trim body option
  */
 function parseRawBody (body, trim) {
-  return `$body = "${sanitize(body.toString(), trim)}"\n`;
+  return `$body = @"${sanitize(body.toString(), trim)}\n"@\n`;
 }
 
 /**

--- a/codegens/powershell-restmethod/lib/index.js
+++ b/codegens/powershell-restmethod/lib/index.js
@@ -82,7 +82,7 @@ function parseFormData (body, trim) {
  * @param {boolean} trim trim body option
  */
 function parseRawBody (body, trim) {
-  return `$body = @"${sanitize(body.toString(), trim, false)}\n"@\n`;
+  return `$body = @"\n${sanitize(body.toString(), trim, false)}\n"@\n`;
 }
 
 /**

--- a/codegens/powershell-restmethod/lib/util.js
+++ b/codegens/powershell-restmethod/lib/util.js
@@ -5,9 +5,10 @@
  *
  * @param {String} inputString
  * @param {Boolean} [trim] - indicates whether to trim string or not
+ * @param {Boolean} shouldEscapeNewLine - indicates whether to escape newline
  * @returns {String}
  */
-function sanitize (inputString, trim) {
+function sanitize (inputString, trim, shouldEscapeNewLine = true) {
   if (typeof inputString !== 'string') {
     return '';
   }
@@ -16,6 +17,10 @@ function sanitize (inputString, trim) {
     .replace(/\$/g, '`$')
     .replace(/\\/g, '\`\\')
     .replace(/\"/g, '\`\"');
+
+  if (shouldEscapeNewLine) {
+    inputString = inputString.replace(/\n/g, '\`n');
+  }
   return trim ? inputString.trim() : inputString;
 }
 

--- a/codegens/powershell-restmethod/lib/util.js
+++ b/codegens/powershell-restmethod/lib/util.js
@@ -15,8 +15,7 @@ function sanitize (inputString, trim) {
     .replace(/`/g, '``')
     .replace(/\$/g, '`$')
     .replace(/\\/g, '\`\\')
-    .replace(/\"/g, '\`\"')
-    .replace(/\n/g, '\`n');
+    .replace(/\"/g, '\`\"');
   return trim ? inputString.trim() : inputString;
 }
 

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -180,13 +180,16 @@ describe('Powershell-restmethod converter', function () {
           expect.fail(null, null, error);
           return;
         }
+
+        console.log(snippet);
         const lines = snippet.split('\n');
         expect(lines[0]).to
           .eql('$headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"');
         expect(lines[1]).to.eql('$headers.Add("Content-Type", "text/plain")');
-        expect(lines[3]).to.eql('$body = "Hello world"');
-        expect(lines[5]).to.eql('$response = Invoke-RestMethod \'https://mockbin.org/request\' -Method \'POST\' -Headers $headers -Body $body -TimeoutSec 10'); // eslint-disable-line max-len
-        expect(lines[6]).to.eql('$response | ConvertTo-Json');
+        expect(lines[3]).to.eql('$body = @"Hello world');
+        expect(lines[4]).to.eql('"@');
+        expect(lines[6]).to.eql('$response = Invoke-RestMethod \'https://mockbin.org/request\' -Method \'POST\' -Headers $headers -Body $body -TimeoutSec 10'); // eslint-disable-line max-len
+        expect(lines[7]).to.eql('$response | ConvertTo-Json');
       });
     });
   });

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -186,10 +186,11 @@ describe('Powershell-restmethod converter', function () {
         expect(lines[0]).to
           .eql('$headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"');
         expect(lines[1]).to.eql('$headers.Add("Content-Type", "text/plain")');
-        expect(lines[3]).to.eql('$body = @"Hello world');
-        expect(lines[4]).to.eql('"@');
-        expect(lines[6]).to.eql('$response = Invoke-RestMethod \'https://mockbin.org/request\' -Method \'POST\' -Headers $headers -Body $body -TimeoutSec 10'); // eslint-disable-line max-len
-        expect(lines[7]).to.eql('$response | ConvertTo-Json');
+        expect(lines[3]).to.eql('$body = @"');
+        expect(lines[4]).to.eql('Hello world');
+        expect(lines[5]).to.eql('"@');
+        expect(lines[7]).to.eql('$response = Invoke-RestMethod \'https://mockbin.org/request\' -Method \'POST\' -Headers $headers -Body $body -TimeoutSec 10'); // eslint-disable-line max-len
+        expect(lines[8]).to.eql('$response | ConvertTo-Json');
       });
     });
   });

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -181,7 +181,6 @@ describe('Powershell-restmethod converter', function () {
           return;
         }
 
-        console.log(snippet);
         const lines = snippet.split('\n');
         expect(lines[0]).to
           .eql('$headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"');

--- a/npm/ci-requirements.sh
+++ b/npm/ci-requirements.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ev; # stop on error
 
+sudo apt-get update
+
 echo "Insalling dependencies required for tests in codegens/libcurl"
 sudo apt-get install libcurl4-gnutls-dev
 


### PR DESCRIPTION
Before:
```
$body = "{`n        `"hello`": `"Wirld`",`n        `"this`": [`n            `"that`",`n            `"`$when`",`n            `"as`"`n        ]`n    }"
```
After:
```
$body = @"
{
        `"hello`": `"Wirld`",
        `"this`": [
            `"that`",
            `"`$when`",
            `"as`"
        ]
    }
"@
````