### PR TITLE
Fix an issue where % was getting double encoded in query params

### DIFF
--- a/codegens/curl/lib/util.js
+++ b/codegens/curl/lib/util.js
@@ -207,7 +207,7 @@ var self = module.exports = {
   },
 
   /**
-   * Encode param except the following characters- [,{,},]
+   * Encode param except the following characters- [,{,},],%
    *
    * @param {String} param
    * @returns {String}
@@ -218,6 +218,7 @@ var self = module.exports = {
       .replace(/%7B/g, '{')
       .replace(/%5D/g, ']')
       .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
       .replace(/'/g, '%27');
   },
 

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -650,6 +650,13 @@ describe('curl convert function', function () {
           expect(outputUrlString).to.equal('https://postman-echo.com/get?key1={{value}}&key2=%27a%20b%20c%27');
         });
 
+        it('should not encode query params that are already encoded', function () {
+          rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
+          urlObject = new sdk.Url(rawUrl);
+          outputUrlString = getUrlStringfromUrlObject(urlObject);
+          expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
+        });
+
         it('should discard disabled query params', function () {
           urlObject = new sdk.Url({
             protocol: 'https',

--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -3,6 +3,7 @@ var _ = require('./lodash'),
   sanitizeMultiline = require('./util').sanitizeMultiline,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   isFile = false,
   self;
 
@@ -243,7 +244,7 @@ self = module.exports = {
     }
     codeSnippet += `${indent}"net/http"\n${indent}"io/ioutil"\n)\n\n`;
 
-    codeSnippet += `func main() {\n\n${indent}url := "${encodeURI(request.url.toString())}"\n`;
+    codeSnippet += `func main() {\n\n${indent}url := "${getUrlStringfromUrlObject(request.url)}"\n`;
     codeSnippet += `${indent}method := "${request.method}"\n\n`;
 
     if (bodySnippet !== '') {

--- a/codegens/golang/lib/util.js
+++ b/codegens/golang/lib/util.js
@@ -1,12 +1,14 @@
-module.exports = {
+const _ = require('./lodash');
+
+const self = module.exports = {
   /**
-     * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
-     * and trim input if required
-     *
-     * @param {String} inputString
-     * @param {Boolean} [trim] - indicates whether to trim string or not
-     * @returns {String}
-     */
+   * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
+   * and trim input if required
+   *
+   * @param {String} inputString
+   * @param {Boolean} [trim] - indicates whether to trim string or not
+   * @returns {String}
+   */
   sanitize: function (inputString, trim) {
     if (typeof inputString !== 'string') {
       return '';
@@ -20,13 +22,13 @@ module.exports = {
   },
 
   /**
-     * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
-     * and trim input if required
-     *
-     * @param {String} inputString
-     * @param {Boolean} [trim] - indicates whether to trim string or not
-     * @returns {String}
-     */
+   * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
+   * and trim input if required
+   *
+   * @param {String} inputString
+   * @param {Boolean} [trim] - indicates whether to trim string or not
+   * @returns {String}
+   */
   sanitizeMultiline: function (inputString, trim) {
     if (typeof inputString !== 'string') {
       return '';
@@ -36,6 +38,90 @@ module.exports = {
       .replace(/\r/g, '`+"\r"+`'); // Go discards \r from raw strings, so manually keep them
     return trim ? inputString.trim() : inputString;
 
+  },
+
+  /**
+   *
+   * @param {Object} urlObject The request sdk request.url object
+   * @returns {String} The final string after parsing all the parameters of the url including
+   * protocol, auth, host, port, path, query, hash
+   * This will be used because the url.toString() method returned the URL with non encoded query string
+   * and hence a manual call is made to getQueryString() method with encode option set as true.
+   */
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = self.getQueryString(urlObject);
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
+
+    return self.sanitize(url, false);
+  },
+
+  /**
+     * @param {Object} urlObject
+     * @returns {String}
+     */
+  getQueryString: function (urlObject) {
+    let isFirstParam = true,
+      params = _.get(urlObject, 'query.members'),
+      result = '';
+    if (Array.isArray(params)) {
+      result = _.reduce(params, function (result, param) {
+        if (param.disabled === true) {
+          return result;
+        }
+
+        if (isFirstParam) {
+          isFirstParam = false;
+        }
+        else {
+          result += '&';
+        }
+
+        return result + self.encodeParam(param.key) + '=' + self.encodeParam(param.value);
+      }, result);
+    }
+
+    return result;
+  },
+
+  /**
+   * Encode param except the following characters- [,{,},],%
+   *
+   * @param {String} param
+   * @returns {String}
+   */
+  encodeParam: function (param) {
+    return encodeURIComponent(param)
+      .replace(/%5B/g, '[')
+      .replace(/%7B/g, '{')
+      .replace(/%5D/g, ']')
+      .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
+      .replace(/'/g, '%27');
   },
 
   /**

--- a/codegens/java-okhttp/lib/okhttp.js
+++ b/codegens/java-okhttp/lib/okhttp.js
@@ -189,7 +189,7 @@ function convert (request, options, callback) {
   if (options.includeBoilerplate) {
     headerSnippet = 'import java.io.*;\n' +
                         'import okhttp3.*;\n' +
-                        'public class main {\n' +
+                        'public class Main {\n' +
                         indentString + 'public static void main(String []args) throws IOException{\n';
     footerSnippet = indentString.repeat(2) + 'System.out.println(response.body().string());\n' +
                         indentString + '}\n}\n';

--- a/codegens/java-okhttp/test/newman/newman.test.js
+++ b/codegens/java-okhttp/test/newman/newman.test.js
@@ -4,9 +4,9 @@ var runNewmanTest = require('../../../../test/codegen/newman/newmanTestUtil').ru
 describe.skip('convert for different request types', function () {
   var options = {indentCount: 3, indentType: 'Space', includeBoilerplate: true},
     testConfig = {
-      compileScript: 'javac -cp *: main.java',
-      runScript: 'java -cp *: main',
-      fileName: 'main.java',
+      compileScript: 'javac -cp *: Main.java',
+      runScript: 'java -cp *: Main',
+      fileName: 'Main.java',
       skipCollections: ['redirectCollection']
     };
   runNewmanTest(convert, options, testConfig);

--- a/codegens/java-okhttp/test/unit/convert.test.js
+++ b/codegens/java-okhttp/test/unit/convert.test.js
@@ -25,7 +25,7 @@ describe('okhttp convert function', function () {
         }
         snippetArray = snippet.split('\n');
         for (var i = 0; i < snippetArray.length; i++) {
-          if (snippetArray[i].startsWith('public class main {')) {
+          if (snippetArray[i].startsWith('public class Main {')) {
             expect(snippetArray[i + 1].substr(0, 4)).to.equal(SINGLE_SPACE.repeat(4));
             expect(snippetArray[i + 1].charAt(4)).to.not.equal(SINGLE_SPACE);
           }
@@ -39,7 +39,7 @@ describe('okhttp convert function', function () {
           expect.fail(null, null, error);
           return;
         }
-        expect(snippet).to.include('import java.io.*;\nimport okhttp3.*;\npublic class main {\n');
+        expect(snippet).to.include('import java.io.*;\nimport okhttp3.*;\npublic class Main {\n');
       });
     });
 

--- a/codegens/java-unirest/lib/parseRequest.js
+++ b/codegens/java-unirest/lib/parseRequest.js
@@ -3,7 +3,7 @@ var _ = require('./lodash'),
   sanitize = require('./util').sanitize;
 
 /**
- * Encode param except the following characters- [,{,},]
+ * Encode param except the following characters- [,{,},],%
  *
  * @param {String} param
  * @returns {String}
@@ -11,9 +11,8 @@ var _ = require('./lodash'),
 function encodeParam (param) {
   return encodeURIComponent(param)
     .replace(/%5B/g, '[')
-    .replace(/%7B/g, '{')
     .replace(/%5D/g, ']')
-    .replace(/%7D/g, '}')
+    .replace(/%25/g, '%')
     .replace(/'/g, '%27');
 }
 

--- a/codegens/java-unirest/lib/unirest.js
+++ b/codegens/java-unirest/lib/unirest.js
@@ -186,7 +186,7 @@ function convert (request, options, callback) {
   if (options.includeBoilerplate) {
     headerSnippet = 'import com.mashape.unirest.http.*;\n' +
                         'import java.io.*;\n' +
-                        'public class main {\n' +
+                        'public class Main {\n' +
                         indentString + 'public static void main(String []args) throws Exception{\n';
     footerSnippet = indentString.repeat(2) + 'System.out.println(response.getBody());\n' +
                         indentString + '}\n}\n';

--- a/codegens/java-unirest/test/newman/newman.test.js
+++ b/codegens/java-unirest/test/newman/newman.test.js
@@ -3,9 +3,9 @@ var runNewmanTest = require('../../../../test/codegen/newman/newmanTestUtil').ru
 
 describe('Convert for different types of request', function () {
   var testConfig = {
-      runScript: 'java -cp *: main',
-      compileScript: 'javac -cp *: main.java',
-      fileName: 'main.java',
+      runScript: 'java -cp *: Main',
+      compileScript: 'javac -cp *: Main.java',
+      fileName: 'Main.java',
       skipCollections: ['formdataCollection', 'emptyFormdataCollection', 'unsupportedMethods']
     },
     options = {includeBoilerplate: true};

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -134,7 +134,7 @@ describe('java unirest convert function for test collection', function () {
       };
       headerSnippet = 'import com.mashape.unirest.http.*;\n' +
                         'import java.io.*;\n' +
-                        'public class main {\n' +
+                        'public class Main {\n' +
                         indentString + 'public static void main(String []args) throws Exception{\n';
       footerSnippet = indentString.repeat(2) + 'System.out.println(response.getBody());\n' +
                         indentString + '}\n}\n';
@@ -218,8 +218,8 @@ describe('java unirest convert function for test collection', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('http://postman-echo.com/post?a={{xyz}}');
-        expect(snippet).to.not.include('http://postman-echo.com/post?a=%7B%7Bxyz%7D%7D');
+        expect(snippet).to.not.include('http://postman-echo.com/post?a={{xyz}}');
+        expect(snippet).to.include('http://postman-echo.com/post?a=%7B%7Bxyz%7D%7D');
       });
     });
 
@@ -479,8 +479,8 @@ describe('java unirest convert function for test collection', function () {
         rawUrl = 'https://postman-echo.com/get?key={{value}}';
         urlObject = new sdk.Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
-        expect(outputUrlString).to.not.include('key=%7B%7Bvalue%7B%7B');
-        expect(outputUrlString).to.equal(rawUrl);
+        expect(outputUrlString).to.include('key=%7B%7Bvalue%7D%7D');
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%7B%7Bvalue%7D%7D');
       });
 
       it('should encode query params other than unresolved variables', function () {
@@ -491,14 +491,21 @@ describe('java unirest convert function for test collection', function () {
         expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
       });
 
+      it('should not encode query params that are already encoded', function () {
+        rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
+      });
+
       it('should not encode unresolved query params and ' +
       'encode every other query param, both present together', function () {
         rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b c\'';
         urlObject = new sdk.Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
-        expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
+        expect(outputUrlString).to.include('key1=%7B%7Bvalue%7D%7D');
         expect(outputUrlString).to.not.include('key2=\'a b c\'');
-        expect(outputUrlString).to.equal('https://postman-echo.com/get?key1={{value}}&key2=%27a%20b%20c%27');
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?key1=%7B%7Bvalue%7D%7D&key2=%27a%20b%20c%27');
       });
 
       it('should discard disabled query params', function () {

--- a/codegens/js-xhr/lib/index.js
+++ b/codegens/js-xhr/lib/index.js
@@ -2,6 +2,7 @@ var _ = require('./lodash'),
   sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   path = require('path');
 
 /**
@@ -278,7 +279,7 @@ function convert (request, options, callback) {
   codeSnippet += `${indent.repeat(2)}console.log(this.responseText);\n`;
   codeSnippet += `${indent}}\n});\n\n`;
 
-  codeSnippet += `xhr.open("${request.method}", "${encodeURI(request.url.toString())}");\n`;
+  codeSnippet += `xhr.open("${request.method}", "${getUrlStringfromUrlObject(request.url)}");\n`;
   if (options.requestTimeout) {
     codeSnippet += `xhr.timeout = ${options.requestTimeout};\n`;
     codeSnippet += 'xhr.addEventListener("ontimeout", function(e) {\n';

--- a/codegens/js-xhr/lib/util.js
+++ b/codegens/js-xhr/lib/util.js
@@ -1,4 +1,6 @@
-module.exports = {
+const _ = require('./lodash');
+
+const self = module.exports = {
   /**
      * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
      * and trim input if required
@@ -85,6 +87,90 @@ module.exports = {
       }
     }
     return result;
+  },
+
+  /**
+   *
+   * @param {Object} urlObject The request sdk request.url object
+   * @returns {String} The final string after parsing all the parameters of the url including
+   * protocol, auth, host, port, path, query, hash
+   * This will be used because the url.toString() method returned the URL with non encoded query string
+   * and hence a manual call is made to getQueryString() method with encode option set as true.
+   */
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = self.getQueryString(urlObject);
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
+
+    return self.sanitize(url, false);
+  },
+
+  /**
+     * @param {Object} urlObject
+     * @returns {String}
+     */
+  getQueryString: function (urlObject) {
+    let isFirstParam = true,
+      params = _.get(urlObject, 'query.members'),
+      result = '';
+    if (Array.isArray(params)) {
+      result = _.reduce(params, function (result, param) {
+        if (param.disabled === true) {
+          return result;
+        }
+
+        if (isFirstParam) {
+          isFirstParam = false;
+        }
+        else {
+          result += '&';
+        }
+
+        return result + self.encodeParam(param.key) + '=' + self.encodeParam(param.value);
+      }, result);
+    }
+
+    return result;
+  },
+
+  /**
+   * Encode param except the following characters- [,{,},],%
+   *
+   * @param {String} param
+   * @returns {String}
+   */
+  encodeParam: function (param) {
+    return encodeURIComponent(param)
+      .replace(/%5B/g, '[')
+      .replace(/%7B/g, '{')
+      .replace(/%5D/g, ']')
+      .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
+      .replace(/'/g, '%27');
   },
 
   /**

--- a/codegens/libcurl/lib/index.js
+++ b/codegens/libcurl/lib/index.js
@@ -1,6 +1,7 @@
 var sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   _ = require('./lodash'),
   self;
 
@@ -39,7 +40,7 @@ self = module.exports = {
     snippet += 'if(curl) {\n';
     snippet += indentString + `curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "${request.method}");\n`;
     snippet += indentString +
-    `curl_easy_setopt(curl, CURLOPT_URL, "${encodeURI(request.url.toString())}");\n`;
+    `curl_easy_setopt(curl, CURLOPT_URL, "${getUrlStringfromUrlObject(request.url)}");\n`;
     if (timeout) {
       snippet += indentString + `curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, ${timeout}L);\n`;
     }

--- a/codegens/libcurl/lib/util.js
+++ b/codegens/libcurl/lib/util.js
@@ -1,4 +1,6 @@
-module.exports = {
+const _ = require('./lodash');
+
+const self = module.exports = {
   /**
      * sanitizes input string by handling escape characters eg: converts '''' to '\'\''
      * and trim input if required
@@ -87,6 +89,90 @@ module.exports = {
     }
 
     return result;
+  },
+
+  /**
+   *
+   * @param {Object} urlObject The request sdk request.url object
+   * @returns {String} The final string after parsing all the parameters of the url including
+   * protocol, auth, host, port, path, query, hash
+   * This will be used because the url.toString() method returned the URL with non encoded query string
+   * and hence a manual call is made to getQueryString() method with encode option set as true.
+   */
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = self.getQueryString(urlObject);
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
+
+    return self.sanitize(url, false);
+  },
+
+  /**
+   * @param {Object} urlObject
+   * @returns {String}
+   */
+  getQueryString: function (urlObject) {
+    let isFirstParam = true,
+      params = _.get(urlObject, 'query.members'),
+      result = '';
+    if (Array.isArray(params)) {
+      result = _.reduce(params, function (result, param) {
+        if (param.disabled === true) {
+          return result;
+        }
+
+        if (isFirstParam) {
+          isFirstParam = false;
+        }
+        else {
+          result += '&';
+        }
+
+        return result + self.encodeParam(param.key) + '=' + self.encodeParam(param.value);
+      }, result);
+    }
+
+    return result;
+  },
+
+  /**
+   * Encode param except the following characters- [,{,},],%
+   *
+   * @param {String} param
+   * @returns {String}
+   */
+  encodeParam: function (param) {
+    return encodeURIComponent(param)
+      .replace(/%5B/g, '[')
+      .replace(/%7B/g, '{')
+      .replace(/%5D/g, ']')
+      .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
+      .replace(/'/g, '%27');
   },
 
   /**

--- a/codegens/nodejs-native/test/newman/newman.test.js
+++ b/codegens/nodejs-native/test/newman/newman.test.js
@@ -7,7 +7,8 @@ describe('Convert for different types of request', function () {
       headerSnippet: '/* eslint-disable */\n',
       compileScript: null,
       runScript: 'node run.js',
-      fileName: 'run.js'
+      fileName: 'run.js',
+      skipCollections: ['queryParamsCollection']
     };
 
   runNewmanTest(convert, options, testConfig);
@@ -18,7 +19,8 @@ describe('Convert for different types of request', function () {
         compileScript: null,
         runScript: 'node run.js',
         fileName: 'run.js',
-        headerSnippet: '/* eslint-disable */\n'
+        headerSnippet: '/* eslint-disable */\n',
+        skipCollections: ['queryParamsCollection']
       };
 
     runNewmanTest(convert, options, testConfig);

--- a/codegens/objective-c/test/newman/newman.test.js
+++ b/codegens/objective-c/test/newman/newman.test.js
@@ -8,7 +8,8 @@ describe.skip('Convert for different types of request', function () {
       compileScript: 'clang -framework Foundation snippet.m -o prog',
       runScript: './prog',
       fileName: 'snippet.m',
-      headerSnippet: ''
+      headerSnippet: '',
+      skipCollections: ['queryParamsCollection']
     };
 
   runNewmanTest(convert, options, testConfig);

--- a/codegens/ocaml-cohttp/lib/ocaml.js
+++ b/codegens/ocaml-cohttp/lib/ocaml.js
@@ -2,6 +2,7 @@ var _ = require('./lodash'),
   sanitize = require('./util').sanitize,
   sanitizeOptions = require('./util').sanitizeOptions,
   addFormParam = require('./util').addFormParam,
+  getUrlStringfromUrlObject = require('./util').getUrlStringfromUrlObject,
   self;
 
 /**
@@ -313,7 +314,7 @@ self = module.exports = {
     // timeout = options.requestTimeout;
     // followRedirect = options.followRedirect;
     trim = options.trimRequestBody;
-    finalUrl = encodeURI(request.url.toString());
+    finalUrl = getUrlStringfromUrlObject(request.url);
     methodArg = getMethodArg(request.method);
     if (request.body && !request.headers.has('Content-Type')) {
       if (request.body.mode === 'file') {

--- a/codegens/ocaml-cohttp/lib/util.js
+++ b/codegens/ocaml-cohttp/lib/util.js
@@ -1,4 +1,6 @@
-module.exports = {
+const _ = require('./lodash');
+
+const self = module.exports = {
   /**
     * sanitization of values : trim, escape characters
     *
@@ -100,6 +102,90 @@ module.exports = {
       }
     }
     return result;
+  },
+
+  /**
+   *
+   * @param {Object} urlObject The request sdk request.url object
+   * @returns {String} The final string after parsing all the parameters of the url including
+   * protocol, auth, host, port, path, query, hash
+   * This will be used because the url.toString() method returned the URL with non encoded query string
+   * and hence a manual call is made to getQueryString() method with encode option set as true.
+   */
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = self.getQueryString(urlObject);
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
+
+    return self.sanitize(url, false);
+  },
+
+  /**
+   * @param {Object} urlObject
+   * @returns {String}
+   */
+  getQueryString: function (urlObject) {
+    let isFirstParam = true,
+      params = _.get(urlObject, 'query.members'),
+      result = '';
+    if (Array.isArray(params)) {
+      result = _.reduce(params, function (result, param) {
+        if (param.disabled === true) {
+          return result;
+        }
+
+        if (isFirstParam) {
+          isFirstParam = false;
+        }
+        else {
+          result += '&';
+        }
+
+        return result + self.encodeParam(param.key) + '=' + self.encodeParam(param.value);
+      }, result);
+    }
+
+    return result;
+  },
+
+  /**
+   * Encode param except the following characters- [,{,},],%
+   *
+   * @param {String} param
+   * @returns {String}
+   */
+  encodeParam: function (param) {
+    return encodeURIComponent(param)
+      .replace(/%5B/g, '[')
+      .replace(/%7B/g, '{')
+      .replace(/%5D/g, ']')
+      .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
+      .replace(/'/g, '%27');
   },
 
   /**

--- a/codegens/php-curl/lib/php-curl.js
+++ b/codegens/php-curl/lib/php-curl.js
@@ -3,6 +3,7 @@ var _ = require('./lodash'),
   sanitize = require('./util/sanitize').sanitize,
   sanitizeOptions = require('./util/sanitize').sanitizeOptions,
   addFormParam = require('./util/sanitize').addFormParam,
+  getUrlStringfromUrlObject = require('./util/sanitize').getUrlStringfromUrlObject,
   self;
 
 /**
@@ -105,11 +106,7 @@ self = module.exports = {
     identity = options.indentType === 'Tab' ? '\t' : ' ';
     indentation = identity.repeat(options.indentCount);
     // concatenation and making up the final string
-    finalUrl = request.url.toString();
-    if (finalUrl !== encodeURI(finalUrl)) {
-      // needs to be encoded
-      finalUrl = encodeURI(finalUrl);
-    }
+    finalUrl = getUrlStringfromUrlObject(request.url);
     snippet = '<?php\n\n$curl = curl_init();\n\n';
     snippet += 'curl_setopt_array($curl, array(\n';
     snippet += `${indentation}CURLOPT_URL => '${sanitize(finalUrl, 'url')}',\n`;

--- a/codegens/php-curl/lib/util/sanitize.js
+++ b/codegens/php-curl/lib/util/sanitize.js
@@ -1,4 +1,6 @@
-module.exports = {
+const _ = require('../lodash');
+
+const self = module.exports = {
 /**
 * sanitization of values : trim, escape characters
 *
@@ -90,6 +92,90 @@ module.exports = {
       }
     }
     return result;
+  },
+
+  /**
+   *
+   * @param {Object} urlObject The request sdk request.url object
+   * @returns {String} The final string after parsing all the parameters of the url including
+   * protocol, auth, host, port, path, query, hash
+   * This will be used because the url.toString() method returned the URL with non encoded query string
+   * and hence a manual call is made to getQueryString() method with encode option set as true.
+   */
+  getUrlStringfromUrlObject: function (urlObject) {
+    var url = '';
+    if (!urlObject) {
+      return url;
+    }
+    if (urlObject.protocol) {
+      url += (urlObject.protocol.endsWith('://') ? urlObject.protocol : urlObject.protocol + '://');
+    }
+    if (urlObject.auth && urlObject.auth.user) {
+      url = url + ((urlObject.auth.password) ?
+        urlObject.auth.user + ':' + urlObject.auth.password : urlObject.auth.user) + '@';
+    }
+    if (urlObject.host) {
+      url += urlObject.getHost();
+    }
+    if (urlObject.port) {
+      url += ':' + urlObject.port.toString();
+    }
+    if (urlObject.path) {
+      url += urlObject.getPath();
+    }
+    if (urlObject.query && urlObject.query.count()) {
+      let queryString = self.getQueryString(urlObject);
+      queryString && (url += '?' + queryString);
+    }
+    if (urlObject.hash) {
+      url += '#' + urlObject.hash;
+    }
+
+    return self.sanitize(url, false);
+  },
+
+  /**
+   * @param {Object} urlObject
+   * @returns {String}
+   */
+  getQueryString: function (urlObject) {
+    let isFirstParam = true,
+      params = _.get(urlObject, 'query.members'),
+      result = '';
+    if (Array.isArray(params)) {
+      result = _.reduce(params, function (result, param) {
+        if (param.disabled === true) {
+          return result;
+        }
+
+        if (isFirstParam) {
+          isFirstParam = false;
+        }
+        else {
+          result += '&';
+        }
+
+        return result + self.encodeParam(param.key) + '=' + self.encodeParam(param.value);
+      }, result);
+    }
+
+    return result;
+  },
+
+  /**
+   * Encode param except the following characters- [,{,},],%
+   *
+   * @param {String} param
+   * @returns {String}
+   */
+  encodeParam: function (param) {
+    return encodeURIComponent(param)
+      .replace(/%5B/g, '[')
+      .replace(/%7B/g, '{')
+      .replace(/%5D/g, ']')
+      .replace(/%7D/g, '}')
+      .replace(/%25/g, '%')
+      .replace(/'/g, '%27');
   },
 
   /**

--- a/codegens/python-http.client/test/newman/newman.test.js
+++ b/codegens/python-http.client/test/newman/newman.test.js
@@ -13,7 +13,8 @@ describe('Convert for different types of request', function () {
     testConfig = {
       fileName: 'codesnippet.py',
       runScript: 'PYTHONIOENCODING=utf-8 python3 codesnippet.py',
-      skipCollections: ['redirectCollection', 'sameNameHeadersCollection', 'unsupportedMethods']
+      skipCollections: ['redirectCollection', 'sameNameHeadersCollection', 'unsupportedMethods',
+        'queryParamsCollection']
     };
   runNewmanTest(convert, options, testConfig);
 });

--- a/codegens/swift/lib/util.js
+++ b/codegens/swift/lib/util.js
@@ -104,7 +104,7 @@ function sanitizeOptions (options, optionsArray) {
 }
 
 /**
- * Encode param except the following characters- [,{,},]
+ * Encode param except the following characters- [,{,},],%
  *
  * @param {String} param
  * @returns {String}
@@ -115,6 +115,7 @@ function encodeParam (param) {
     .replace(/%7B/g, '{')
     .replace(/%5D/g, ']')
     .replace(/%7D/g, '}')
+    .replace(/%25/g, '%')
     .replace(/'/g, '%27');
 }
 

--- a/codegens/swift/test/unit/convert.test.js
+++ b/codegens/swift/test/unit/convert.test.js
@@ -332,6 +332,13 @@ describe('Swift Converter', function () {
         expect(outputUrlString).to.equal('https://postman-echo.com/get?key1={{value}}&key2=%27a%20b%20c%27');
       });
 
+      it('should not encode query params that are already encoded', function () {
+        rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
+        urlObject = new sdk.Url(rawUrl);
+        outputUrlString = getUrlStringfromUrlObject(urlObject);
+        expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
+      });
+
       it('should discard disabled query params', function () {
         urlObject = new sdk.Url({
           protocol: 'https',

--- a/test/codegen/newman/fixtures/queryParamsCollection.json
+++ b/test/codegen/newman/fixtures/queryParamsCollection.json
@@ -1,0 +1,31 @@
+{
+	"info": {
+		"_postman_id": "0bb73926-93f7-4ad4-a191-6a5d9e3460ef",
+		"name": "Query Params Collection",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Query Param with encoded value",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://postman-echo.com/query=urn%3Ali%3Afoo%3A62324",
+					"host": [
+						"https://postman-echo.com"
+					],
+					"path": [
+						"get"
+					],
+					"query": [
+						{
+							"key": "query",
+							"value": "urn%3Ali%3Afoo%3A62324"
+						}
+					]
+				}
+			}
+		}
+  ]
+}


### PR DESCRIPTION
As part of https://github.com/postmanlabs/postman-code-generators/pull/638, we moved the encoding to the modules, which led to double encoding.

The fix would be to remove double encoding and make this fix in all other modules as well which are now doing double encoding of `%`.