### PR TITLE
Removes unused `fs` import on NodeJS - Native codegen

### DIFF
--- a/codegens/nodejs-native/lib/request.js
+++ b/codegens/nodejs-native/lib/request.js
@@ -34,13 +34,6 @@ function makeSnippet (request, indentString, options) {
   else {
     snippet += `${nativeModule} = require('${nativeModule}');\n`;
   }
-  if (options.ES6_enabled) {
-    snippet += 'const ';
-  }
-  else {
-    snippet += 'var ';
-  }
-  snippet += 'fs = require(\'fs\');\n\n';
   if (_.get(request, 'body.mode') && request.body.mode === 'urlencoded') {
     if (options.ES6_enabled) {
       snippet += 'const ';


### PR DESCRIPTION
This PR removes the unused `fs` import on the NodeJS - Native codegen. 


Fixes https://github.com/postmanlabs/postman-code-generators/issues/708