### PR TITLE
Swift Async

### DIFF
--- a/ADDITIONAL_DEPENDENCIES.md
+++ b/ADDITIONAL_DEPENDENCIES.md
@@ -37,7 +37,7 @@
   1. [wget](https://www.gnu.org/software/wget)
 
 ### swift 
-  1. [swift-5.0.1](https://swift.org/builds/swift-5.0.1-release/ubuntu1604/swift-5.0.1-RELEASE)
+  1. [swift-5.5](https://download.swift.org/swift-5.5-release/ubuntu1604/swift-5.5-RELEASE)
   2. clang-3.6
   3. libicu-dev
   4. libpython2.7

--- a/codegens/swift/test/newman/newman.test.js
+++ b/codegens/swift/test/newman/newman.test.js
@@ -2,10 +2,11 @@ var runNewmanTest = require('../../../../test/codegen/newman/newmanTestUtil').ru
   convert = require('../../lib/index').convert;
 
 describe('Convert for different types of request', function () {
-  var options = {
+  const options = {
       includeBoilerplate: true,
       indentType: 'Space',
-      indentCount: 4
+      indentCount: 4,
+      asyncAwaitEnabled: false
     },
     // if running locally on mac change the runScript to 'swift snippet.swift'
     testConfig = {
@@ -14,4 +15,20 @@ describe('Convert for different types of request', function () {
       skipCollections: ['sameNameHeadersCollection', 'unsupportedMethods']
     };
   runNewmanTest(convert, options, testConfig);
+
+  describe('Convert for request incorporating async/await features', function () {
+    const options = {
+        includeBoilerplate: true,
+        indentType: 'Space',
+        indentCount: 4,
+        asyncAwaitEnabled: true
+      },
+      testConfig = {
+        fileName: 'snippet.swift',
+        runScript: 'swift-5.7.3-RELEASE-ubuntu20.04/usr/bin/swift snippet.swift',
+        skipCollections: ['sameNameHeadersCollection', 'unsupportedMethods']
+      };
+
+    runNewmanTest(convert, options, testConfig);
+  });
 });


### PR DESCRIPTION
- Added async option for Swift code snippet options.
  - Default as `false`, traditional completion handler style.
- Changed EXIT_SUCCESS on existing version to EXIT_FAILURE where it actually fails.

The async code looks like:

```swift
do {
    let (data, response) = try await URLSession.shared.data(for: request)
    print(String(data: data, encoding: .utf8)!)
    exit(EXIT_SUCCESS)
} catch {
    print("A URL error occurred: \(error)")
    exit(EXIT_FAILURE)
}
```

Current non-async code:

```swift
let task = URLSession.shared.dataTask(with: request) { data, response, error in 
    guard let data = data else {
        print(String(describing: error))
        exit(EXIT_FAILURE)
    }
    print(String(data: data, encoding: .utf8)!)
    exit(EXIT_SUCCESS)
}
```

IMO the async method should be default, but wanted to get your feedback first!

> I have noted in ADDITIONAL_DEPENDENCIES.md that the swift version should be a minimum of 5.5 (released Sept 2021)