### PR TITLE
fix php codegen missing ?> at end of snippet (fixes #640)

### DIFF
--- a/codegens/php-curl/lib/php-curl.js
+++ b/codegens/php-curl/lib/php-curl.js
@@ -178,7 +178,8 @@ self = module.exports = {
     snippet += '));\n\n';
     snippet += '$response = curl_exec($curl);\n\n';
     snippet += 'curl_close($curl);\n';
-    snippet += 'echo $response;\n';
+    snippet += 'echo $response;\n\n';
+    snippet += '?>';
 
     return callback(null, snippet);
   }

--- a/codegens/php-guzzle/lib/phpGuzzle.js
+++ b/codegens/php-guzzle/lib/phpGuzzle.js
@@ -160,10 +160,12 @@ function getSnippetBoilerplate (includeBoilerplate) {
 function getSnippetFooterSync (includeRequestOptions) {
   if (!includeRequestOptions) {
     return '$res = $client->send($request);\n' +
-    'echo $res->getBody();\n';
+    'echo $res->getBody();\n\n' +
+    '?>';
   }
   return '$res = $client->send($request, $options);\n' +
-  'echo $res->getBody();\n';
+  'echo $res->getBody();\n\n' +
+  '?>';
 }
 
 /**
@@ -176,10 +178,12 @@ function getSnippetFooterSync (includeRequestOptions) {
 function getSnippetFooterAsync (includeRequestOptions) {
   if (!includeRequestOptions) {
     return '$res = $client->sendAsync($request)->wait();\n' +
-    'echo $res->getBody();\n';
+    'echo $res->getBody();\n\n' +
+    '?>';
   }
   return '$res = $client->sendAsync($request, $options)->wait();\n' +
-  'echo $res->getBody();\n';
+  'echo $res->getBody();\n\n' +
+  '?>';
 }
 
 /**

--- a/codegens/php-httprequest2/lib/index.js
+++ b/codegens/php-httprequest2/lib/index.js
@@ -187,7 +187,9 @@ self = module.exports = {
     snippet += `${indentString.repeat(2)}$response->getReasonPhrase();\n`;
     snippet += `${indentString}}\n`;
     snippet += '}\ncatch(HTTP_Request2_Exception $e) {\n';
-    snippet += `${indentString}echo 'Error: ' . $e->getMessage();\n}`;
+    snippet += `${indentString}echo 'Error: ' . $e->getMessage();\n}\n\n`;
+    snippet += `?>`;
+    
     return callback(null, snippet);
   }
 };

--- a/codegens/php-pecl-http/lib/phpPecl.js
+++ b/codegens/php-pecl-http/lib/phpPecl.js
@@ -175,7 +175,8 @@ self = module.exports = {
     snippet += `${getHeaders(request, indentation)}\n`;
     snippet += '$client->enqueue($request)->send();\n';
     snippet += '$response = $client->getResponse();\n';
-    snippet += 'echo $response->getBody();\n';
+    snippet += 'echo $response->getBody();\n\n';
+    snippet += '?>';
 
     return callback(null, snippet);
   }


### PR DESCRIPTION
Fixes #640 
Issue: The code generators for php, generates snippet without ?> end tag.

Code Snippet:
`<?php

$curl = curl_init();

curl_setopt_array($curl, array(
  CURLOPT_URL => 'https://postman-echo.com/get?test=123',
  CURLOPT_RETURNTRANSFER => true,
  CURLOPT_ENCODING => '',
  CURLOPT_MAXREDIRS => 10,
  CURLOPT_TIMEOUT => 0,
  CURLOPT_FOLLOWLOCATION => true,
  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
  CURLOPT_CUSTOMREQUEST => 'GET',
));

$response = curl_exec($curl);

curl_close($curl);
echo $response;
`

The Code snippet after the fix looks like:
`<?php

$curl = curl_init();

curl_setopt_array($curl, array(
  CURLOPT_URL => 'https://postman-echo.com/get?test=123',
  CURLOPT_RETURNTRANSFER => true,
  CURLOPT_ENCODING => '',
  CURLOPT_MAXREDIRS => 10,
  CURLOPT_TIMEOUT => 0,
  CURLOPT_FOLLOWLOCATION => true,
  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
  CURLOPT_CUSTOMREQUEST => 'GET',
));

$response = curl_exec($curl);

curl_close($curl);
echo $response;

?>`
