### PR TITLE
Upgrade postman-collection to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "4.17.21",
     "async": "3.2.2",
     "path": "0.12.7",
-    "postman-collection": "4.0.0",
+    "postman-collection": "4.4.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {


### PR DESCRIPTION
`postman-collection` version `4.0.0` depends on a vulnerable version of `semver`. https://github.com/postmanlabs/postman-code-generators/pull/738 would be a preferable solution and this should be merged only if that PR is not accepted for some reason