### PR TITLE
fix python.http-client generate code snippet using http

### DIFF
--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -140,7 +140,12 @@ self = module.exports = {
       snippet += 'from codecs import encode\n';
     }
     snippet += '\n';
-    snippet += `conn = http.client.HTTPSConnection("${sanitize(host)}"`;
+    if (request.url.protocol === 'http') {
+      snippet += `conn = http.client.HTTPConnection("${sanitize(host)}"`;
+    }
+    else {
+      snippet += `conn = http.client.HTTPSConnection("${sanitize(host)}"`;
+    }
     snippet += url.port ? `, ${request.url.port}` : '';
     snippet += options.requestTimeout !== 0 ? `, timeout = ${options.requestTimeout})\n` : ')\n';
 

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -336,6 +336,29 @@ describe('Python-http.client converter', function () {
       });
     });
 
+    it('should generate valid snippets when url uses http protocol', function () {
+      var request = new sdk.Request({
+        'method': 'GET',
+        'header': [],
+        'url': {
+          'raw': 'http://localhost:3000',
+          'protocol': 'http',
+          'host': [
+            'localhost'
+          ],
+          'port': '3000'
+        },
+        'response': []
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.include('conn = http.client.HTTPConnection("localhost", 3000)');
+      });
+    });
+
   });
 
   describe('parseBody function', function () {


### PR DESCRIPTION
## Problem
[Associated Issue](https://github.com/postmanlabs/postman-code-generators/issues/746)
For url using http protocol, python.http-client still generates conn = http.client.HTTPSConnection. Python would throw SSL error when running the script.

## Fix
Generate the code snippet based on the received url protocol.

## Test
Added unit test case.