### PR TITLE
Updated "postman-collection" usage to be specific to part of module being used.

### DIFF
--- a/codegens/csharp-httpclient/test/unit/convert.test.js
+++ b/codegens/csharp-httpclient/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert,
   mainCollection = require('./fixtures/testcollection/collection.json'),
   testCollection = require('./fixtures/testcollection/collectionForEdge.json'),
@@ -13,7 +13,7 @@ describe('csharp httpclient function', function () {
 
   describe('csharp-httpclient convert function', function () {
     it('should return expected snippet', function () {
-      var request = new sdk.Request(mainCollection.item[10].request),
+      var request = new Request(mainCollection.item[10].request),
         options = {
           indentCount: 1,
           indentType: 'Tab'
@@ -30,7 +30,7 @@ describe('csharp httpclient function', function () {
   });
 
   describe('convert function', function () {
-    var request = new sdk.Request(testCollection.item[0].request),
+    var request = new Request(testCollection.item[0].request),
       snippetArray,
       options = {
         includeBoilerplate: true,
@@ -89,7 +89,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should create custom HttpMethod when method is non-standard', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'NOTNORMAL',
         'header': [],
         'url': {
@@ -116,7 +116,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should add fake body when content type header added to empty body', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'DELETE',
         'body': {},
         'header': [
@@ -137,7 +137,7 @@ describe('csharp httpclient function', function () {
     });
 
     // it('should only include one System.IO using with multiple files', function () {
-    //   var request = new sdk.Request({
+    //   var request = new Request({
     //     'method': 'POST',
     //     'header': [],
     //     'body': {
@@ -171,7 +171,7 @@ describe('csharp httpclient function', function () {
     // });
 
     it('should include multiple form content when file has multiple sources', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -201,7 +201,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should include graphql body in the snippet', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -236,7 +236,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should add blank graphql variables when invalid', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -271,7 +271,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should not add multiport form content when disabled', function () {
-      var request = new sdk.Request(mainCollection.item[15].request);
+      var request = new Request(mainCollection.item[15].request);
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -288,7 +288,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should run add content as string on raw request', function () {
-      var request = new sdk.Request(mainCollection.item[12].request);
+      var request = new Request(mainCollection.item[12].request);
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -303,7 +303,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should add a file on file request', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'url': 'https://google.com',
         'header': [],
@@ -324,7 +324,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should add all enabled headers to request', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'url': 'https://postman-echo.com/post',
         'header': [
@@ -360,7 +360,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should skip disabled form url encoded values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'url': 'https://postman-echo.com/post',
@@ -390,7 +390,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should skip collection initialization when no urlencoded values are enabled', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'url': 'https://postman-echo.com/post',
@@ -415,7 +415,7 @@ describe('csharp httpclient function', function () {
     });
 
     it('should skip creating multipart form data content when all values are disabled', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'url': 'https://postman-echo.com/post',

--- a/codegens/csharp-restsharp/test/unit/convert.test.js
+++ b/codegens/csharp-restsharp/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert,
   mainCollection = require('./fixtures/testcollection/collection.json'),
   testCollection = require('./fixtures/testcollection/collectionForEdge.json'),
@@ -13,7 +13,7 @@ describe('csharp restsharp function', function () {
 
   describe('csharp-restsharp convert function', function () {
     it('should return expected snippet - Async', function () {
-      var request = new sdk.Request(mainCollection.item[4].request),
+      var request = new Request(mainCollection.item[4].request),
         options = {
           indentCount: 1,
           indentType: 'Tab',
@@ -31,7 +31,7 @@ describe('csharp restsharp function', function () {
     });
 
     it('should return expected snippet json params', function () {
-      var request = new sdk.Request(mainCollection.item[5].request),
+      var request = new Request(mainCollection.item[5].request),
         options = {
           indentCount: 1,
           indentType: 'Tab',
@@ -50,7 +50,7 @@ describe('csharp restsharp function', function () {
   });
 
   describe('convert function', function () {
-    var request = new sdk.Request(testCollection.item[0].request),
+    var request = new Request(testCollection.item[0].request),
       snippetArray,
       options = {
         includeBoilerplate: true,
@@ -108,7 +108,7 @@ describe('csharp restsharp function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -136,7 +136,7 @@ describe('csharp restsharp function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -188,7 +188,7 @@ describe('csharp restsharp function', function () {
       const sampleUA = 'Safari/605.1.15',
         expectValue = `UserAgent = "${sampleUA}",`;
 
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../index').convert,
   getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject;
 
@@ -9,7 +10,7 @@ describe('curl convert function', function () {
 
     it('should return snippet with carat(^) as line continuation ' +
             'character for multiline code generation', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -35,7 +36,7 @@ describe('curl convert function', function () {
     });
 
     it('should return snippet with url in single quote(\')', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -57,7 +58,7 @@ describe('curl convert function', function () {
     });
 
     it('should return snippet with url in double quote(")', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -79,7 +80,7 @@ describe('curl convert function', function () {
     });
 
     it('should add semicolon after header key, if the value is empty string', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -110,7 +111,7 @@ describe('curl convert function', function () {
 
     it('should return snippet with backslash(\\) as line continuation ' +
             'character for multiline code generation by default', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -136,7 +137,7 @@ describe('curl convert function', function () {
 
     it('should return snippet with backtick(`) as line continuation ' +
             'character for multiline code generation', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -162,7 +163,7 @@ describe('curl convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -198,7 +199,7 @@ describe('curl convert function', function () {
     });
 
     it('should parse header with string value properly', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -230,7 +231,7 @@ describe('curl convert function', function () {
         ']world',
         'world}'
       ].forEach(function (value) {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'GET',
           'url': {
             'raw': `http://example.com?hello=${value}`,
@@ -263,7 +264,7 @@ describe('curl convert function', function () {
     });
 
     it('should return snippet without errors when request object has no body property', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -289,7 +290,7 @@ describe('curl convert function', function () {
 
     it('should return snippet with backslash(\\) character as line continuation ' +
          'character for multiline code generation', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -316,7 +317,7 @@ describe('curl convert function', function () {
 
     it('should not encode queryParam unresolved variables and ' +
     'leave it inside double parenthesis {{xyz}}', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -349,7 +350,7 @@ describe('curl convert function', function () {
     });
 
     it('should encode queryParams other than unresolved variables', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -382,7 +383,7 @@ describe('curl convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -411,7 +412,7 @@ describe('curl convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -461,7 +462,7 @@ describe('curl convert function', function () {
 
     it('should generate valid snippets for single/double quotes in URL', function () {
       // url = https://a"b'c.com/'d/"e
-      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      var request = new Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -474,7 +475,7 @@ describe('curl convert function', function () {
 
     it('should generate valid snippets when quoteType is "double"', function () {
       // url = https://a"b'c.com/'d/"e
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -506,7 +507,7 @@ describe('curl convert function', function () {
     });
 
     it('should not add appropriate escaping characters when quote type is "double"', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -538,7 +539,7 @@ describe('curl convert function', function () {
     });
 
     it('should escape special characters when quoteType is "double"', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -572,7 +573,7 @@ describe('curl convert function', function () {
     });
 
     it('should longer option for body even if longFormat is disabled if @ character is present', function () {
-      let request = new sdk.Request({
+      let request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -606,7 +607,7 @@ describe('curl convert function', function () {
 
       it('should return empty string for an url object for an empty url or if no url object is passed', function () {
         rawUrl = '';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.be.empty;
         outputUrlString = getUrlStringfromUrlObject();
@@ -615,14 +616,14 @@ describe('curl convert function', function () {
 
       it('should add protocol if present in the url object', function () {
         rawUrl = 'https://postman-echo.com';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
 
       it('should add the auth information if present in the url object', function () {
         rawUrl = 'https://user:password@postman-echo.com';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
@@ -630,28 +631,28 @@ describe('curl convert function', function () {
       it('should not add the auth information if user isn\'t present but' +
       ' password is present in the url object', function () {
         rawUrl = 'https://:password@postman-echo.com';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.not.include(':password');
       });
 
       it('should add host if present in the url object', function () {
         rawUrl = 'https://postman-echo.com';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
 
       it('should add port if present in the url object', function () {
         rawUrl = 'https://postman-echo.com:8080';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
 
       it('should add path if present in the url object', function () {
         rawUrl = 'https://postman-echo.com/get';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
@@ -660,7 +661,7 @@ describe('curl convert function', function () {
 
         it('should not encode unresolved query params', function () {
           rawUrl = 'https://postman-echo.com/get?key={{value}}';
-          urlObject = new sdk.Url(rawUrl);
+          urlObject = new Url(rawUrl);
           outputUrlString = getUrlStringfromUrlObject(urlObject);
           expect(outputUrlString).to.not.include('key=%7B%7Bvalue%7B%7B');
           expect(outputUrlString).to.equal(rawUrl);
@@ -668,7 +669,7 @@ describe('curl convert function', function () {
 
         it('should encode query params other than unresolved variables', function () {
           rawUrl = 'https://postman-echo.com/get?key=\'a b c\'';
-          urlObject = new sdk.Url(rawUrl);
+          urlObject = new Url(rawUrl);
           outputUrlString = getUrlStringfromUrlObject(urlObject);
           expect(outputUrlString).to.not.include('key=\'a b c\'');
           expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
@@ -677,7 +678,7 @@ describe('curl convert function', function () {
         it('should not encode unresolved query params and ' +
         'encode every other query param, both present together', function () {
           rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'';
-          urlObject = new sdk.Url(rawUrl);
+          urlObject = new Url(rawUrl);
           outputUrlString = getUrlStringfromUrlObject(urlObject);
           expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
           expect(outputUrlString).to.not.include('key2=\'a b+c\'');
@@ -686,13 +687,13 @@ describe('curl convert function', function () {
 
         it('should not encode query params that are already encoded', function () {
           rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
-          urlObject = new sdk.Url(rawUrl);
+          urlObject = new Url(rawUrl);
           outputUrlString = getUrlStringfromUrlObject(urlObject);
           expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
         });
 
         it('should discard disabled query params', function () {
-          urlObject = new sdk.Url({
+          urlObject = new Url({
             protocol: 'https',
             host: 'postman-echo.com',
             query: [
@@ -707,14 +708,14 @@ describe('curl convert function', function () {
 
       it('should add hash if present in the url object', function () {
         rawUrl = 'https://postmanm-echo.com/get#hash';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal(rawUrl);
       });
     });
 
     it('should not add --request parameter in POST request if body is present', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -747,7 +748,7 @@ describe('curl convert function', function () {
     });
 
     it('should add --request parameter in POST request if body is not present', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -773,7 +774,7 @@ describe('curl convert function', function () {
     });
 
     it('should add --request parameter in GET request if body is present', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [],
         'body': {
@@ -807,7 +808,7 @@ describe('curl convert function', function () {
 
     it('should not add --request parameter in GET request if body is present ' +
       'but disableBodyPruning is false', function () {
-      const request = new sdk.Request({
+      const request = new Request({
         'method': 'GET',
         'header': [],
         'body': {
@@ -846,7 +847,7 @@ describe('curl convert function', function () {
 
     describe('followRedirect and followOriginalHttpMethod', function () {
       it('should add --request parameter when passed true via options', function () {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'POST',
           'header': [],
           'body': {
@@ -879,7 +880,7 @@ describe('curl convert function', function () {
       });
 
       it('should not add --request parameter when passed false via options', function () {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'POST',
           'header': [],
           'body': {
@@ -912,7 +913,7 @@ describe('curl convert function', function () {
       });
 
       it('should add --request parameter when passed false via options but true in request settings', function () {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'POST',
           'header': [],
           'body': {
@@ -951,7 +952,7 @@ describe('curl convert function', function () {
       });
 
       it('should not add --request parameter when passed true via options but false in request settings', function () {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'POST',
           'header': [],
           'body': {
@@ -990,7 +991,7 @@ describe('curl convert function', function () {
       });
 
       it('should work when protocolProfileBehavior is null in request settings', function () {
-        const request = new sdk.Request({
+        const request = new Request({
           'method': 'POST',
           'header': [],
           'body': {

--- a/codegens/dart-dio/test/unit/convert.test.js
+++ b/codegens/dart-dio/test/unit/convert.test.js
@@ -5,7 +5,7 @@ var convert = require('../../index').convert,
 // Disable check with expected snippets as we now have proper newman tests
 describe('Dart Converter', function () {
   it('should add timeout if requestTimeout options is used', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -40,7 +40,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add code for followRedirects if given in the option', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'url': {
@@ -62,7 +62,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add boilerplate if given in the option', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'url': {
@@ -85,7 +85,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add correct indentation', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/dart-dio/test/unit/convert.test.js
+++ b/codegens/dart-dio/test/unit/convert.test.js
@@ -1,6 +1,6 @@
 var convert = require('../../index').convert,
   expect = require('chai').expect,
-  sdk = require('postman-collection');
+  { Request } = require('postman-collection/lib/collection/request');
 
 // Disable check with expected snippets as we now have proper newman tests
 describe('Dart Converter', function () {

--- a/codegens/dart-http/test/unit/convert.test.js
+++ b/codegens/dart-http/test/unit/convert.test.js
@@ -1,6 +1,6 @@
 var convert = require('../../index').convert,
   expect = require('chai').expect,
-  sdk = require('postman-collection');
+  { Request } = require('postman-collection/lib/collection/request');
 
 // Disable check with expected snippets as we now have proper newman tests
 describe('Dart Converter', function () {

--- a/codegens/dart-http/test/unit/convert.test.js
+++ b/codegens/dart-http/test/unit/convert.test.js
@@ -5,7 +5,7 @@ var convert = require('../../index').convert,
 // Disable check with expected snippets as we now have proper newman tests
 describe('Dart Converter', function () {
   it('should add timeout if requestTimeout options is used', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -40,7 +40,7 @@ describe('Dart Converter', function () {
   });
 
   it('should use http.MultipartRequest for formdata requests', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -69,7 +69,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add code for followRedirects if given in the option', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'url': {
@@ -91,7 +91,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add boilerplate if given in the option', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'url': {
@@ -114,7 +114,7 @@ describe('Dart Converter', function () {
   });
 
   it('should add correct indentation', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/golang/test/unit/convert.test.js
+++ b/codegens/golang/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../index').convert,
   getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject;
 
@@ -8,7 +9,7 @@ describe('Golang convert function', function () {
     var request, options;
 
     it('should return snippet without errors when request object has no body property', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -34,7 +35,7 @@ describe('Golang convert function', function () {
     });
 
     it('should parse headers with string value properly', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -67,7 +68,7 @@ describe('Golang convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -106,7 +107,7 @@ describe('Golang convert function', function () {
     });
 
     it('should add time converted to seconds when input is taken in milliseconds ', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -131,7 +132,7 @@ describe('Golang convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -158,7 +159,7 @@ describe('Golang convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -208,7 +209,7 @@ describe('Golang convert function', function () {
 
     it('should add error handling code everytime an error is possible', function () {
       var requests = [];
-      requests.push(new sdk.Request({
+      requests.push(new Request({
         'method': 'GET',
         'header': [
           {
@@ -225,7 +226,7 @@ describe('Golang convert function', function () {
           ]
         }
       }));
-      requests.push(new sdk.Request({
+      requests.push(new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -258,7 +259,7 @@ describe('Golang convert function', function () {
     it('should not encode unresolved query params and ' +
     'encode every other query param, both present together', function () {
       let rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'',
-        urlObject = new sdk.Url(rawUrl),
+        urlObject = new Url(rawUrl),
         outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
       expect(outputUrlString).to.not.include('key2=\'a b+c\'');

--- a/codegens/http/lib/code-http-converter.js
+++ b/codegens/http/lib/code-http-converter.js
@@ -1,6 +1,6 @@
 let utils = require('./util'),
   _ = require('./lodash'),
-  sdk = require('postman-collection');
+  { Url } = require('postman-collection/lib/collection/url');
 
 /**
  * Used in order to get additional options for generation of C# code snippet (i.e. Include Boilerplate code)
@@ -33,7 +33,7 @@ function convert (request, options, callback) {
     url, host, path, query, body, headers;
   options = utils.sanitizeOptions(options, getOptions());
 
-  url = sdk.Url.parse(request.url.toString());
+  url = Url.parse(request.url.toString());
   host = url.host ? url.host.join('.') : '';
   host += url.port ? ':' + url.port : '';
   path = url.path ? '/' + url.path.join('/') : '/';

--- a/codegens/http/package.json
+++ b/codegens/http/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/postmanlabs/code-generators/tree/master/codegens/http",
   "dependencies": {
-    "postman-collection": "3.6.8"
+    "postman-collection": "^4.4.0"
   },
   "scripts": {
     "test": "node npm/test.js",

--- a/codegens/java-okhttp/test/unit/convert.test.js
+++ b/codegens/java-okhttp/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util').sanitize,
   convert = require('../../lib/index').convert,
   getOptions = require('../../lib/index').getOptions,
@@ -7,7 +7,7 @@ var expect = require('chai').expect,
 
 describe('okhttp convert function', function () {
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       snippetArray,
       options = {
         includeBoilerplate: true,
@@ -81,7 +81,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -108,7 +108,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -143,7 +143,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {

--- a/codegens/java-unirest/test/unit/convert.test.js
+++ b/codegens/java-unirest/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../lib/index').convert,
   sanitize = require('../../lib/util').sanitize,
   getUrlStringfromUrlObject = require('../../lib/parseRequest').getUrlStringfromUrlObject,
@@ -18,7 +19,7 @@ describe('java unirest convert function for test collection', function () {
       line_no;
 
     it('should return a Tab indented snippet ', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         indentType: 'Tab',
         indentCount: 1
@@ -43,7 +44,7 @@ describe('java unirest convert function for test collection', function () {
     });
 
     it('should return snippet with setTimeouts function when timeout is set to non zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -59,7 +60,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should return snippet with setTimeouts function setting both ' +
             'connection and socket timeout to 0 when requestTimeout is set to 0', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 0
       };
@@ -75,7 +76,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should return snippet with disableRedirectHandling function for' +
             'follow redirect option set to false', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: false
       };
@@ -90,7 +91,7 @@ describe('java unirest convert function for test collection', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -126,7 +127,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should include import statements, main class and print statements ' +
             'when includeBoilerplate is set to true', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         includeBoilerplate: true,
         indentType: 'Tab',
@@ -156,7 +157,7 @@ describe('java unirest convert function for test collection', function () {
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST'
       };
-      request = new sdk.Request(reqObject);
+      request = new Request(reqObject);
       options = {};
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -177,7 +178,7 @@ describe('java unirest convert function for test collection', function () {
         'url': 'https://postman-echo.com/request',
         'method': 'PROPFIND'
       };
-      request = new sdk.Request(reqObject);
+      request = new Request(reqObject);
       options = {};
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -192,7 +193,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should not encode queryParam unresolved variables and ' +
     'leave it inside double parenthesis {{xyz}}', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -224,7 +225,7 @@ describe('java unirest convert function for test collection', function () {
     });
 
     it('should encode queryParams other than unresolved variables', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -256,7 +257,7 @@ describe('java unirest convert function for test collection', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -284,7 +285,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should add the force multipart body method when ' +
       'there are no files but contains text field params in multipart/form-data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'body': {
           'mode': 'formdata',
@@ -323,7 +324,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should not add the force multipart body method when ' +
       'there are file fields in multipart/form-data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'body': {
           'mode': 'formdata',
@@ -359,7 +360,7 @@ describe('java unirest convert function for test collection', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -407,7 +408,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should generate valid snippets for single/double quotes in URL', function () {
       // url = https://a"b'c.com/'d/"e
-      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      var request = new Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -423,7 +424,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should return empty string for an url object for an empty url or if no url object is passed', function () {
       rawUrl = '';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.be.empty;
       outputUrlString = getUrlStringfromUrlObject();
@@ -432,14 +433,14 @@ describe('java unirest convert function for test collection', function () {
 
     it('should add protocol if present in the url object', function () {
       rawUrl = 'https://postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add the auth information if present in the url object', function () {
       rawUrl = 'https://user:password@postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
@@ -447,28 +448,28 @@ describe('java unirest convert function for test collection', function () {
     it('should not add the auth information if user isn\'t present but' +
     ' password is present in the url object', function () {
       rawUrl = 'https://:password@postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include(':password');
     });
 
     it('should add host if present in the url object', function () {
       rawUrl = 'https://postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add port if present in the url object', function () {
       rawUrl = 'https://postman-echo.com:8080';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add path if present in the url object', function () {
       rawUrl = 'https://postman-echo.com/get';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
@@ -477,7 +478,7 @@ describe('java unirest convert function for test collection', function () {
 
       it('should not encode unresolved query params', function () {
         rawUrl = 'https://postman-echo.com/get?key={{value}}';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.include('key=%7B%7Bvalue%7D%7D');
         expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%7B%7Bvalue%7D%7D');
@@ -485,7 +486,7 @@ describe('java unirest convert function for test collection', function () {
 
       it('should encode query params other than unresolved variables', function () {
         rawUrl = 'https://postman-echo.com/get?key=\'a b c\'';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.not.include('key=\'a b c\'');
         expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
@@ -493,7 +494,7 @@ describe('java unirest convert function for test collection', function () {
 
       it('should not encode query params that are already encoded', function () {
         rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
       });
@@ -501,7 +502,7 @@ describe('java unirest convert function for test collection', function () {
       it('should not encode unresolved query params and ' +
       'encode every other query param, both present together', function () {
         rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.include('key1=%7B%7Bvalue%7D%7D');
         expect(outputUrlString).to.not.include('key2=\'a b+c\'');
@@ -509,7 +510,7 @@ describe('java unirest convert function for test collection', function () {
       });
 
       it('should discard disabled query params', function () {
-        urlObject = new sdk.Url({
+        urlObject = new Url({
           protocol: 'https',
           host: 'postman-echo.com',
           query: [
@@ -524,7 +525,7 @@ describe('java unirest convert function for test collection', function () {
 
     it('should add hash if present in the url object', function () {
       rawUrl = 'https://postmanm-echo.com/get#hash';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });

--- a/codegens/js-fetch/test/unit/convert.test.js
+++ b/codegens/js-fetch/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util').sanitize,
   getOptions = require('../../index').getOptions,
   convert = require('../../index').convert,
@@ -13,7 +13,7 @@ describe('js-fetch convert function for test collection', function () {
       line_no;
 
     it('should return a Space indented snippet ', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         indentType: 'Space',
         indentCount: 2
@@ -34,7 +34,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should return snippet with no setTimeout function when timeout is set to zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 0
       };
@@ -49,7 +49,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -84,7 +84,7 @@ describe('js-fetch convert function for test collection', function () {
 
     it('should return snippet with redirect property set to manual for ' +
                 'no follow redirect', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: false
       };
@@ -100,7 +100,7 @@ describe('js-fetch convert function for test collection', function () {
 
     it('should return snippet with redirect property set to follow for ' +
                 ' follow redirect', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: true
       };
@@ -115,7 +115,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should default to mode raw body mode is some random value', function () {
-      request = new sdk.Request(mainCollection.item[2].request);
+      request = new Request(mainCollection.item[2].request);
       request.body.mode = 'random';
       request.body[request.body.mode] = {};
       options = {};
@@ -130,7 +130,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should generate snippet for no body provided', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'GET',
         'url': {
           'raw': 'https://postman-echo.com/request',
@@ -153,7 +153,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -181,7 +181,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should include JSON.stringify in the snippet for raw json bodies', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -215,7 +215,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -264,7 +264,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should generate valid snippet for single/double quotes in url', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -299,7 +299,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should return snippet with promise based code when async_await is disabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, {}, function (error, snippet) {
         if (error) {
@@ -313,7 +313,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should return snippet with async/await based code when option is enabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, { asyncAwaitEnabled: true }, function (error, snippet) {
         if (error) {
@@ -327,7 +327,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should return timeout snippet with promise based code when async_await is disabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, { requestTimeout: 3000 }, function (error, snippet) {
         if (error) {
@@ -341,7 +341,7 @@ describe('js-fetch convert function for test collection', function () {
     });
 
     it('should return timeout snippet with promise based code when async_await is enabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, { requestTimeout: 3000, asyncAwaitEnabled: true }, function (error, snippet) {
         if (error) {

--- a/codegens/js-jquery/test/unit/converter.test.js
+++ b/codegens/js-jquery/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   fs = require('fs'),
 
   convert = require('../../lib/index').convert,
@@ -25,7 +25,7 @@ describe('jQuery converter', function () {
 
   mainCollection.item.forEach(function (item) {
     it(item.name, function (done) {
-      var request = new sdk.Request(item.request);
+      var request = new Request(item.request);
       convert(request, {indentType: 'Space',
         indentCount: 4,
         requestTimeout: 100,
@@ -42,7 +42,7 @@ describe('jQuery converter', function () {
   });
 
   it('should return snippet without errors when request object has no body property', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -74,7 +74,7 @@ describe('jQuery converter', function () {
   });
 
   it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-    let request = new sdk.Request({
+    let request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -108,7 +108,7 @@ describe('jQuery converter', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -134,7 +134,7 @@ describe('jQuery converter', function () {
     });
   });
   it('should include JSON.stringify in the snippet for raw json bodies', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -168,7 +168,7 @@ describe('jQuery converter', function () {
   });
 
   it('should include graphql body in the snippet', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -201,7 +201,7 @@ describe('jQuery converter', function () {
   });
 
   it('should generate snippets(not error out) for requests with multiple/no file in formdata', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -267,7 +267,7 @@ describe('jQuery converter', function () {
   });
 
   it('should generate valid snippet for multiple headers with same name', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -304,7 +304,7 @@ describe('jQuery converter', function () {
   });
 
   it('should generate snippet for form data params with no type key present', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       method: 'POST',
       header: [],
       url: {

--- a/codegens/js-xhr/test/unit/convert.test.js
+++ b/codegens/js-xhr/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   sanitize = require('../../lib/util.js').sanitize,
   getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject,
   convert = require('../../index').convert,
@@ -8,7 +9,7 @@ var expect = require('chai').expect,
 describe('js-xhr convert function', function () {
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -36,7 +37,7 @@ describe('js-xhr convert function', function () {
   });
 
   it('should include JSON.stringify in the snippet for raw json bodies', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -70,7 +71,7 @@ describe('js-xhr convert function', function () {
   });
 
   it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-    let request = new sdk.Request({
+    let request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -104,7 +105,7 @@ describe('js-xhr convert function', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -165,7 +166,7 @@ describe('js-xhr convert function', function () {
     it('should not encode unresolved query params and ' +
     'encode every other query param, both present together', function () {
       let rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'',
-        urlObject = new sdk.Url(rawUrl),
+        urlObject = new Url(rawUrl),
         outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
       expect(outputUrlString).to.not.include('key2=\'a b+c\'');
@@ -232,7 +233,7 @@ describe('js-xhr convert function', function () {
         'description': 'The HTTP `POST` request with formData'
       },
 
-      request = new sdk.Request(req),
+      request = new Request(req),
       options = {
         indentCount: 2,
         indentType: 'Space',
@@ -277,7 +278,7 @@ describe('js-xhr convert function', function () {
         'description': 'Request without a body'
       },
 
-      request = new sdk.Request(req),
+      request = new Request(req),
       options = {
         indentCount: 2,
         indentType: 'Space'
@@ -317,7 +318,7 @@ describe('js-xhr convert function', function () {
         'description': 'Request without a body'
       },
 
-      request = new sdk.Request(req),
+      request = new Request(req),
       options = {
         indentCount: 2,
         indentType: 'Space'

--- a/codegens/kotlin-okhttp/test/unit/convert.test.js
+++ b/codegens/kotlin-okhttp/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util').sanitize,
   convert = require('../../lib/index').convert,
   getOptions = require('../../lib/index').getOptions,
@@ -7,7 +7,7 @@ var expect = require('chai').expect,
 
 describe('okhttp convert function', function () {
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request);
+    var request = new Request(mainCollection.item[0].request);
 
     it('should generate snippet with default options given no options', function () {
       convert(request, function (error, snippet) {
@@ -59,7 +59,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -86,7 +86,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -121,7 +121,7 @@ describe('okhttp convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {

--- a/codegens/libcurl/test/unit/convert.test.js
+++ b/codegens/libcurl/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../index').convert,
   getOptions = require('../../index').getOptions,
   getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject,
@@ -22,7 +23,7 @@ describe('libcurl convert function', function () {
     });
 
     it('should set CURLOPT_TIMEOUT_MS parameter when requestTimeout is set to non zero value', function () {
-      var request = new sdk.Request(mainCollection.item[0].request),
+      var request = new Request(mainCollection.item[0].request),
         options = { requestTimeout: 3000 };
 
       convert(request, options, function (error, snippet) {
@@ -35,7 +36,7 @@ describe('libcurl convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -63,7 +64,7 @@ describe('libcurl convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -98,7 +99,7 @@ describe('libcurl convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -148,7 +149,7 @@ describe('libcurl convert function', function () {
     });
 
     it('should free up headers list after request is sent', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -211,7 +212,7 @@ describe('libcurl convert function', function () {
     it('should not encode unresolved query params and ' +
     'encode every other query param, both present together', function () {
       let rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'',
-        urlObject = new sdk.Url(rawUrl),
+        urlObject = new Url(rawUrl),
         outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
       expect(outputUrlString).to.not.include('key2=\'a b+c\'');

--- a/codegens/nodejs-axios/test/unit/snippet.test.js
+++ b/codegens/nodejs-axios/test/unit/snippet.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util').sanitize,
   parseBody = require('../../lib/parseRequest').parseBody,
   getOptions = require('../../lib/index').getOptions,
@@ -15,7 +15,7 @@ describe('nodejs-axios convert function', function () {
       line_no;
 
     it('should return a Tab indented snippet ', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         indentType: 'Tab',
         indentCount: 1
@@ -35,7 +35,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should return snippet with timeout property when timeout is set to non zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -50,7 +50,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -86,7 +86,7 @@ describe('nodejs-axios convert function', function () {
     describe('maxRedirects property', function () {
       it('should return snippet with maxRedirects property set to ' +
       '0 for no follow redirect', function () {
-        const request = new sdk.Request(mainCollection.item[0].request);
+        const request = new Request(mainCollection.item[0].request);
         options = {
           followRedirect: false
         };
@@ -102,7 +102,7 @@ describe('nodejs-axios convert function', function () {
 
       it('should return snippet with maxRedirects property set to ' +
       '0 for no follow redirect from request settings', function () {
-        const request = new sdk.Request(mainCollection.item[0].request),
+        const request = new Request(mainCollection.item[0].request),
           options = {};
 
         request.protocolProfileBehavior = {
@@ -121,7 +121,7 @@ describe('nodejs-axios convert function', function () {
 
       it('should return snippet with no maxRedirects property when ' +
         'follow redirect is true from request settings', function () {
-        const request = new sdk.Request(mainCollection.item[0].request),
+        const request = new Request(mainCollection.item[0].request),
           options = {};
 
         request.protocolProfileBehavior = {
@@ -145,7 +145,7 @@ describe('nodejs-axios convert function', function () {
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST'
       };
-      request = new sdk.Request(reqObject);
+      request = new Request(reqObject);
       convert(request, options, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -157,7 +157,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should not fail for a random body mode', function () {
-      request = new sdk.Request(mainCollection.item[2].request);
+      request = new Request(mainCollection.item[2].request);
       request.body.mode = 'random';
       request.body[request.body.mode] = {};
 
@@ -173,7 +173,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should generate snippet for file body mode', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST',
         'body': {
@@ -198,7 +198,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -252,7 +252,7 @@ describe('nodejs-axios convert function', function () {
           console.log(error);
         });
         */
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {};
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -273,7 +273,7 @@ describe('nodejs-axios convert function', function () {
 
     it('should return snippet with no trailing comma when requestTimeout ' +
       'is set to non zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -291,7 +291,7 @@ describe('nodejs-axios convert function', function () {
 
     it('should return snippet with just a single comma when requestTimeout ' +
       'is set to non zero and followRedirect as false', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000,
         followRedirect: false,
@@ -311,7 +311,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should not require unused fs', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://postman-echo.com/get',
         'method': 'GET',
         'body': {
@@ -329,7 +329,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should add fs for form-data file upload', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://postman-echo.com/post',
         'method': 'POST',
         'body': {
@@ -353,7 +353,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -380,7 +380,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should include JSON.stringify in the snippet for raw json bodies', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -414,7 +414,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -463,7 +463,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should return snippet with maxBodyLength property as "Infinity"', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -478,7 +478,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should return snippet with promise based code when async_await is disabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, {}, function (error, snippet) {
         if (error) {
@@ -492,7 +492,7 @@ describe('nodejs-axios convert function', function () {
     });
 
     it('should return snippet with async/await based code when option is enabled', function () {
-      const request = new sdk.Request(mainCollection.item[0].request);
+      const request = new Request(mainCollection.item[0].request);
 
       convert(request, { asyncAwaitEnabled: true }, function (error, snippet) {
         if (error) {

--- a/codegens/nodejs-native/lib/request.js
+++ b/codegens/nodejs-native/lib/request.js
@@ -1,5 +1,5 @@
 const _ = require('./lodash'),
-  sdk = require('postman-collection'),
+  { Url } = require('postman-collection/lib/collection/url'),
   sanitizeOptions = require('./util').sanitizeOptions,
   sanitize = require('./util').sanitize,
   addFormParam = require('./util').addFormParam,
@@ -132,7 +132,7 @@ function makeSnippet (request, indentString, options) {
   }
 
 
-  url = sdk.Url.parse(request.url.toString());
+  url = Url.parse(request.url.toString());
   host = url.host ? url.host.join('.') : '';
   path = url.path ? '/' + url.path.join('/') : '/';
   query = url.query ? _.reduce(url.query, (accum, q) => {

--- a/codegens/nodejs-native/test/unit/snippet.test.js
+++ b/codegens/nodejs-native/test/unit/snippet.test.js
@@ -1,10 +1,10 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert;
 
 describe('nodejs-native convert function', function () {
   it('should sustain path variables when request has no path and has query params', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'body': {},
@@ -42,7 +42,7 @@ describe('nodejs-native convert function', function () {
 
   it('should parse the url correctly even if the host and path are wrong in the url object',
     function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'body': {
           'mode': 'raw',
@@ -70,7 +70,7 @@ describe('nodejs-native convert function', function () {
     });
 
   it('should add port in the options when host has port specified', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -96,7 +96,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-    let request = new sdk.Request({
+    let request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -130,7 +130,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -157,7 +157,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should add content type if formdata field contains a content-type', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'body': {
         'mode': 'formdata',
@@ -192,7 +192,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -236,7 +236,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should include JSON.stringify in the snippet for raw json bodies', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -269,7 +269,7 @@ describe('nodejs-native convert function', function () {
     });
   });
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -317,7 +317,7 @@ describe('nodejs-native convert function', function () {
     });
   });
   it('should generate valid snippet for single/double quotes in url', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'url': {
@@ -353,7 +353,7 @@ describe('nodejs-native convert function', function () {
   });
 
   it('should generate valid snippet and should include appropriate variable name', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'body': {},
@@ -371,7 +371,7 @@ describe('nodejs-native convert function', function () {
 
   it('should generate valid snippet paths for single/double quotes in URL', function () {
     // url = https://a"b'c.com/'d/"e
-    var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+    var request = new Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
     convert(request, {}, function (error, snippet) {
       if (error) {
         expect.fail(null, null, error);

--- a/codegens/nodejs-request/test/unit/snippet.test.js
+++ b/codegens/nodejs-request/test/unit/snippet.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util').sanitize,
   parseBody = require('../../lib/parseRequest').parseBody,
   getOptions = require('../../lib/index').getOptions,
@@ -15,7 +15,7 @@ describe('nodejs-request convert function', function () {
       line_no;
 
     it('should return a Tab indented snippet ', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         indentType: 'Tab',
         indentCount: 1
@@ -36,7 +36,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -70,7 +70,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should return snippet with timeout property when timeout is set to non zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -86,7 +86,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should return snippet with ES6 features when ES6_enabled is set to true', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         ES6_enabled: true
       };
@@ -106,7 +106,7 @@ describe('nodejs-request convert function', function () {
 
     it('should return snippet with followRedirect property set to ' +
         'false for no follow redirect', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: false
       };
@@ -127,7 +127,7 @@ describe('nodejs-request convert function', function () {
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST'
       };
-      request = new sdk.Request(reqObject);
+      request = new Request(reqObject);
       convert(request, options, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -139,7 +139,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should not fail for a random body mode', function () {
-      request = new sdk.Request(mainCollection.item[2].request);
+      request = new Request(mainCollection.item[2].request);
       request.body.mode = 'random';
       request.body[request.body.mode] = {};
 
@@ -155,7 +155,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should generate snippet for file body mode', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST',
         'body': {
@@ -196,7 +196,7 @@ describe('nodejs-request convert function', function () {
          if (error) throw new Error(error);
          console.log(response.body);
        }); */
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {};
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -220,7 +220,7 @@ describe('nodejs-request convert function', function () {
 
     it('should return snippet with no trailing comma when requestTimeout ' +
       'is set to non zero and followRedirect as true', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -238,7 +238,7 @@ describe('nodejs-request convert function', function () {
 
     it('should return snippet with just a single comma when requestTimeout ' +
       'is set to non zero and followRedirect as false', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000,
         followRedirect: false,
@@ -258,7 +258,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should not require unused fs', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://postman-echo.com/get',
         'method': 'GET',
         'body': {
@@ -276,7 +276,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should add fs for form-data file upload', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://postman-echo.com/post',
         'method': 'POST',
         'body': {
@@ -300,7 +300,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -327,7 +327,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should include JSON.stringify in the snippet for raw json bodies', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -361,7 +361,7 @@ describe('nodejs-request convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {

--- a/codegens/nodejs-unirest/test/unit/snippet.test.js
+++ b/codegens/nodejs-unirest/test/unit/snippet.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert,
   getOptions = require('../../lib/index').getOptions,
   sanitize = require('../../lib/util').sanitize,
@@ -12,7 +12,7 @@ describe('nodejs unirest convert function', function () {
     var request, reqObject, options, snippetArray, line_no;
 
     it('should return a Tab indented snippet ', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         indentType: 'Tab',
         indentCount: 1
@@ -34,7 +34,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should return snippet with timeout function when timeout is set to non zero', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -49,7 +49,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should use JSON.parse if the content-type is application/vnd.api+json', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -83,7 +83,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should return snippet with ES6 features', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         ES6_enabled: true
       };
@@ -103,7 +103,7 @@ describe('nodejs unirest convert function', function () {
 
     it('should return snippet with followRedirect function having ' +
         'parameter false for no follow redirect', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: false
       };
@@ -123,7 +123,7 @@ describe('nodejs unirest convert function', function () {
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST'
       };
-      request = new sdk.Request(reqObject);
+      request = new Request(reqObject);
       options = {};
       convert(request, options, function (error, snippet) {
         if (error) {
@@ -137,7 +137,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -164,7 +164,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should include JSON.stringify in the snippet for raw json bodies', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -198,7 +198,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -245,7 +245,7 @@ describe('nodejs unirest convert function', function () {
     });
 
     it('should generate valid snippet for single/double quotes in url', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {

--- a/codegens/objective-c/test/unit/convert.test.js
+++ b/codegens/objective-c/test/unit/convert.test.js
@@ -1,14 +1,14 @@
 var convert = require('../../index').convert,
   expect = require('chai').expect,
   collection = require('./fixtures/collection.json'),
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   expectedSnippets = require('./fixtures/snippets.json');
 
 describe('Objective-C-NSURLSession Converter', function () {
   describe('convert for different request types', function () {
     collection.item.forEach((item) => {
       it(item.name, function (done) {
-        const request = new sdk.Request(item.request);
+        const request = new Request(item.request);
         convert(request, {}, (err, snippet) => {
           if (err) {
             expect.fail(null, null, err);
@@ -24,7 +24,7 @@ describe('Objective-C-NSURLSession Converter', function () {
 
 describe('Options Tests', function () {
   it('should indent snippet with type and count specified', function () {
-    var request = new sdk.Request(collection.item[0].request);
+    var request = new Request(collection.item[0].request);
     convert(request, {
       indentType: 'Tab',
       indentCount: 2
@@ -46,7 +46,7 @@ describe('Options Tests', function () {
   });
 
   it('should use all the default options', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -84,7 +84,7 @@ describe('Options Tests', function () {
   });
 
   it('should add code for requestTimeout option', function () {
-    var request = new sdk.Request(collection.item[0].request);
+    var request = new Request(collection.item[0].request);
     convert(request, {
       requestTimeout: 5000
     }, function (error, snippet) {
@@ -97,7 +97,7 @@ describe('Options Tests', function () {
   });
 
   it('should trim request body when trimRequestBody is set to true', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -129,7 +129,7 @@ describe('Options Tests', function () {
   });
 
   it('should include boiler plate if includeBoilerplate is set to true', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/ocaml-cohttp/test/unit/convert.test.js
+++ b/codegens/ocaml-cohttp/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../index').convert,
   getOptions = require('../../index').getOptions,
   sanitize = require('../../lib/util').sanitize,
@@ -9,7 +10,7 @@ var expect = require('chai').expect,
 describe('Ocaml unit tests', function () {
 
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       snippetArray;
 
     const SINGLE_SPACE = ' ';
@@ -64,7 +65,7 @@ describe('Ocaml unit tests', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -91,7 +92,7 @@ describe('Ocaml unit tests', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -130,7 +131,7 @@ describe('Ocaml unit tests', function () {
 
 
     it('should include graphql body in the snippet', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -163,7 +164,7 @@ describe('Ocaml unit tests', function () {
     });
 
     it('should generate snippets(not error out) for requests with multiple/no file in formdata', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -250,7 +251,7 @@ describe('Ocaml unit tests', function () {
     it('should not encode unresolved query params and ' +
     'encode every other query param, both present together', function () {
       let rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'',
-        urlObject = new sdk.Url(rawUrl),
+        urlObject = new Url(rawUrl),
         outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
       expect(outputUrlString).to.not.include('key2=\'a b+c\'');

--- a/codegens/php-curl/test/unit/converter.test.js
+++ b/codegens/php-curl/test/unit/converter.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../lib/index').convert,
   getUrlStringfromUrlObject = require('../../lib/util/sanitize').getUrlStringfromUrlObject;
 
@@ -10,7 +11,7 @@ describe('php-curl converter', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -38,7 +39,7 @@ describe('php-curl converter', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -89,7 +90,7 @@ describe('php-curl converter', function () {
   it('should not encode unresolved query params and ' +
   'encode every other query param, both present together', function () {
     let rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'',
-      urlObject = new sdk.Url(rawUrl),
+      urlObject = new Url(rawUrl),
       outputUrlString = getUrlStringfromUrlObject(urlObject);
     expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
     expect(outputUrlString).to.not.include('key2=\'a b+c\'');

--- a/codegens/php-guzzle/test/unit/convert.test.js
+++ b/codegens/php-guzzle/test/unit/convert.test.js
@@ -1,11 +1,11 @@
 var expect = require('chai').expect,
   { convert } = require('../../index'),
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path');
 
 describe('convert function', function () {
-  const collection = new sdk.Collection(JSON.parse(
+  const collection = new Collection(JSON.parse(
     fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
 
   it('should convert requests with asyncType option as async', function (done) {

--- a/codegens/php-guzzle/test/unit/parseBody.test.js
+++ b/codegens/php-guzzle/test/unit/parseBody.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path'),
   {
@@ -10,7 +10,7 @@ var expect = require('chai').expect,
 describe('parseBody function', function () {
 
   it('should parse a raw json Body', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body,
       indentation = '  ',
@@ -21,7 +21,7 @@ describe('parseBody function', function () {
   });
 
   it('should parse a raw json Body with indentation', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body,
       indentation = '   ',
@@ -32,7 +32,7 @@ describe('parseBody function', function () {
   });
 
   it('should parse a raw xml Body', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[10].request.body,
       indentation = '   ',
@@ -43,7 +43,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-url-encoded params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[7].request.body,
       indentation = '  ',
@@ -62,7 +62,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-data params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[4].request.body,
       indentation = '  ',
@@ -99,7 +99,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-data params with a file', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[26].request.body,
       indentation = '  ',
@@ -120,7 +120,7 @@ describe('parseBody function', function () {
   });
 
   it('should return binary data params with a file', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[25].request.body,
       indentation = '  ',
@@ -132,7 +132,7 @@ describe('parseBody function', function () {
   });
 
   it('should return graphql params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[27].request.body,
       indentation = '  ',
@@ -147,7 +147,7 @@ describe('parseBody function', function () {
   });
 
   it('should return empty form data', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[28].request.body,
       indentation = '  ',

--- a/codegens/php-guzzle/test/unit/phpGuzzle.test.js
+++ b/codegens/php-guzzle/test/unit/phpGuzzle.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path'),
 
@@ -21,7 +21,7 @@ var expect = require('chai').expect,
 describe('convert function', function () {
 
   it('should convert a simple get request', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString())));
     convert(collection.items.members[0].request, {includeBoilerplate: true}, function (err, snippet) {
       if (err) {
@@ -38,7 +38,7 @@ describe('convert function', function () {
   });
 
   it('should convert a simple get request without boilerplate', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString())));
     convert(collection.items.members[0].request, {includeBoilerplate: false}, function (err, snippet) {
       if (err) {
@@ -53,14 +53,14 @@ describe('convert function', function () {
 
 describe('getHeaders function', function () {
   it('should return an array of headers', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       headers = getHeaders(collection.items.members[0].request);
     expect(headers.length).to.equal(3);
   });
 
   it('should return an empty array of headers', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       headers = getHeaders(collection.items.members[3].request);
     expect(headers.length).to.equal(0);
@@ -147,7 +147,7 @@ describe('getSnippetHeaders function', function () {
 
 describe('getURL function', function () {
   it('should return an simple string from url object', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString())));
     expect(getURL(collection.items.members[0].request)).to.equal('https://postman-echo.com/headers');
   });
@@ -155,7 +155,7 @@ describe('getURL function', function () {
 
 describe('getMethod function', function () {
   it('should return an simple string representing the method from collection', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString())));
     expect(getMethod(collection.items.members[0].request)).to.equal('GET');
   });

--- a/codegens/php-httprequest2/test/unit/converter.test.js
+++ b/codegens/php-httprequest2/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert,
   sanitize = require('../../lib/util/sanitize').sanitize,
   mainCollection = require('../unit/fixtures/sample_collection.json'),
@@ -15,7 +15,7 @@ describe('PHP HTTP_Request2 converter', function () {
 
   mainCollection.item.forEach(function (item) {
     it(item.name, function (done) {
-      var request = new sdk.Request(item.request);
+      var request = new Request(item.request);
       convert(request, {
         indentType: 'Space',
         indentCount: 2,
@@ -32,7 +32,7 @@ describe('PHP HTTP_Request2 converter', function () {
   });
 
   it('should indent snippet with type and count specified', function () {
-    var request = new sdk.Request(mainCollection.item[0].request);
+    var request = new Request(mainCollection.item[0].request);
     convert(request, {
       indentType: 'Tab',
       indentCount: 2
@@ -55,7 +55,7 @@ describe('PHP HTTP_Request2 converter', function () {
 
   it('should add code for followRedirect option when set and vice versa' +
     '(HTTP_Request2 doesn\'t follow redirect by default)', function () {
-    var request = new sdk.Request(mainCollection.item[0].request);
+    var request = new Request(mainCollection.item[0].request);
     convert(request, {
       followRedirect: true
     }, function (error, snippet) {
@@ -78,7 +78,7 @@ describe('PHP HTTP_Request2 converter', function () {
   });
 
   it('should add code for requestTimeout option', function () {
-    var request = new sdk.Request(mainCollection.item[0].request);
+    var request = new Request(mainCollection.item[0].request);
     convert(request, {
       requestTimeout: 5000
     }, function (error, snippet) {
@@ -91,7 +91,7 @@ describe('PHP HTTP_Request2 converter', function () {
   });
 
   it('should trim request body when trimRequestBody is set to true', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -125,7 +125,7 @@ describe('PHP HTTP_Request2 converter', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/php-pecl-http/test/unit/converter.test.js
+++ b/codegens/php-pecl-http/test/unit/converter.test.js
@@ -1,11 +1,12 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   convert = require('../../lib').convert,
   getOptions = require('../../lib').getOptions,
   sanitize = require('../../lib/util/sanitize').sanitize,
   parseBody = require('../../lib/util/parseBody'),
-  collection = new sdk.Collection(JSON.parse(fs.readFileSync('test/unit/fixtures/sample_collection.json').toString()));
+  collection = new Collection(JSON.parse(fs.readFileSync('test/unit/fixtures/sample_collection.json').toString()));
 
 describe('Request Snippet', function () {
 
@@ -456,7 +457,7 @@ describe('Request Snippet', function () {
   });
 
   it('should not have script closing tag ?>', function () {
-    var collection = new sdk.Collection(JSON.parse(
+    var collection = new Collection(JSON.parse(
         fs.readFileSync('test/unit/fixtures/sample_collection.json').toString())),
       request = collection.items.members[0].request;
     convert(request, function (error, snippet) {
@@ -469,7 +470,7 @@ describe('Request Snippet', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -585,7 +586,7 @@ describe('Request Snippet', function () {
     });
 
     it('should include graphql body in the snippet', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -618,7 +619,7 @@ describe('Request Snippet', function () {
     });
 
     it('should generate snippets(not error out) for requests with multiple/no file in formdata', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {

--- a/codegens/powershell-restmethod/test/unit/convert.test.js
+++ b/codegens/powershell-restmethod/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   exec = require('shelljs').exec,
   newman = require('newman'),
   parallel = require('async').parallel,
@@ -116,7 +116,7 @@ describe('Powershell-restmethod converter', function () {
     mainCollection.item.forEach(function (item) {
       // Skipping tests for Travis CI, till powershell dependency issue is sorted on travis
       it.skip(item.name, function (done) {
-        var request = new sdk.Request(item.request),
+        var request = new Request(item.request),
           collection = {
             item: [
               {
@@ -168,7 +168,7 @@ describe('Powershell-restmethod converter', function () {
           },
           'description': 'Description'
         },
-        pmRequest = new sdk.Request(request),
+        pmRequest = new Request(request),
         options = {
           requestTimeout: 10000,
           multiLine: true,
@@ -198,7 +198,7 @@ describe('Powershell-restmethod converter', function () {
     var request,
       options;
     it('should add a TimeoutSec argument when timeout is set to non zero value', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 1000
       };
@@ -213,7 +213,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should not add a TimeoutSec argument when timeout is set to 0', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         requestTimeout: 0
       };
@@ -228,7 +228,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should add a MaximumRedirection set to 0 argument when followRedirect is not allowed', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: false
       };
@@ -243,7 +243,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should not add a MaximumRedirection argument when followRedirect is allowed', function () {
-      request = new sdk.Request(mainCollection.item[0].request);
+      request = new Request(mainCollection.item[0].request);
       options = {
         followRedirect: true
       };
@@ -258,7 +258,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should default to mode raw when body mode is some random value', function () {
-      request = new sdk.Request(mainCollection.item[2].request);
+      request = new Request(mainCollection.item[2].request);
       request.body.mode = 'random';
       request.body[request.body.mode] = {};
       options = {};
@@ -272,7 +272,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should generate snippet for file body mode', function () {
-      request = new sdk.Request({
+      request = new Request({
         'url': 'https://echo.getpostman.com/post',
         'method': 'POST',
         'body': {
@@ -297,7 +297,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -324,7 +324,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should include graphql body in the snippet', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -357,7 +357,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should generate snippets(not error out) for requests with multiple/no file in formdata', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -426,7 +426,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -462,7 +462,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should generate valid snippet for single/double quotes in url', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -499,7 +499,7 @@ describe('Powershell-restmethod converter', function () {
     });
 
     it('should generate valid snippet when single quotes in custom request method', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         // eslint-disable-next-line quotes
         'method': "TEST';DIR;#'",
         'header': [],
@@ -538,7 +538,7 @@ describe('Powershell-restmethod converter', function () {
 
 
     it('should generate snippet for form data params with no type key present', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         method: 'POST',
         header: [],
         url: {

--- a/codegens/python-http.client/lib/python-httpclient.js
+++ b/codegens/python-http.client/lib/python-httpclient.js
@@ -1,5 +1,5 @@
 var _ = require('./lodash'),
-  sdk = require('postman-collection'),
+  { Url } = require('postman-collection/lib/collection/url'),
   sanitize = require('./util/sanitize').sanitize,
   sanitizeOptions = require('./util/sanitize').sanitizeOptions,
   addFormParam = require('./util/sanitize').addFormParam,
@@ -113,7 +113,7 @@ self = module.exports = {
     identity = options.indentType === 'Tab' ? '\t' : ' ';
     indentation = identity.repeat(options.indentCount);
 
-    url = sdk.Url.parse(request.url.toString());
+    url = Url.parse(request.url.toString());
     host = url.host ? url.host.join('.') : '';
     path = url.path ? '/' + url.path.join('/') : '/';
     query = url.query ? _.reduce(url.query, (accum, q) => {

--- a/codegens/python-http.client/test/unit/converter.test.js
+++ b/codegens/python-http.client/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert,
   getOptions = require('../../lib/index').getOptions,
   parseBody = require('../../lib/util/parseBody'),
@@ -9,7 +9,7 @@ var expect = require('chai').expect,
 describe('Python-http.client converter', function () {
 
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       snippetArray;
 
     const SINGLE_SPACE = ' ';
@@ -37,7 +37,7 @@ describe('Python-http.client converter', function () {
 
     it('should parse the url correctly even if the host and path are wrong in the url object',
       function () {
-        var request = new sdk.Request({
+        var request = new Request({
           'method': 'GET',
           'body': {
             'mode': 'raw',
@@ -65,7 +65,7 @@ describe('Python-http.client converter', function () {
       });
 
     it('should add content type if formdata field contains a content-type', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -100,7 +100,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should convert JSON tokens into appropriate python tokens', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [
           {
@@ -154,7 +154,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should generate snippet with requestTimeout option', function () {
-      var request = new sdk.Request(mainCollection.item[0].request);
+      var request = new Request(mainCollection.item[0].request);
       convert(request, { requestTimeout: 2000 }, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -165,7 +165,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should generate snippet when url is not provied', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'name': 'test',
         'request': {
           'method': 'GET',
@@ -186,7 +186,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should generate snippet with correct indent when body mode is formdata', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -220,7 +220,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should add port in the options when host has port specified', function () {
-      var request = new sdk.Request({
+      var request = new Request({
           'method': 'GET',
           'header': [],
           'url': {
@@ -246,7 +246,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -273,7 +273,7 @@ describe('Python-http.client converter', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -324,7 +324,7 @@ describe('Python-http.client converter', function () {
 
     it('should generate valid snippets for single/double quotes in URL', function () {
       // url = https://a"b'c.com/'d/"e
-      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      var request = new Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -339,7 +339,7 @@ describe('Python-http.client converter', function () {
   });
 
   describe('parseBody function', function () {
-    var requestEmptyFormdata = new sdk.Request({
+    var requestEmptyFormdata = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -347,7 +347,7 @@ describe('Python-http.client converter', function () {
           'formdata': []
         }
       }),
-      requestEmptyUrlencoded = new sdk.Request({
+      requestEmptyUrlencoded = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -355,7 +355,7 @@ describe('Python-http.client converter', function () {
           'urlencoded': []
         }
       }),
-      requestEmptyRaw = new sdk.Request({
+      requestEmptyRaw = new Request({
         'method': 'POST',
         'header': [],
         'body': {

--- a/codegens/python-requests/test/unit/converter.test.js
+++ b/codegens/python-requests/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   mainCollection = require('./fixtures/sample_collection.json'),
   convert = require('../../lib/index').convert;
 
@@ -11,7 +11,7 @@ describe('Python- Requests converter', function () {
 
   it('should not have allow_redirects=False twice in generated snippet when' +
   ' followRedirect option is set as false', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       options = { followRedirect: false, requestTimeout: 0 };
     convert(request, options, function (err, snippet) {
       if (err) {
@@ -24,7 +24,7 @@ describe('Python- Requests converter', function () {
 
   it('should have correct boolean value for allow_redirects(False, uppercased F) in generated snippet when' +
   ' followRedirect option is set as false', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       options = { followRedirect: false };
     convert(request, options, function (err, snippet) {
       if (err) {
@@ -37,7 +37,7 @@ describe('Python- Requests converter', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -64,7 +64,7 @@ describe('Python- Requests converter', function () {
   });
 
   it('should convert JSON tokens into appropriate python tokens', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         {
@@ -102,7 +102,7 @@ describe('Python- Requests converter', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/r-httr/test/unit/convert.test.js
+++ b/codegens/r-httr/test/unit/convert.test.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect,
   { convert } = require('../../index'),
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path');
 
@@ -8,7 +8,7 @@ var expect = require('chai').expect,
 describe('convert function', function () {
 
   it('should convert a simple get request', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[1].request, {}, function (err, snippet) {
       if (err) {
@@ -21,7 +21,7 @@ describe('convert function', function () {
   });
 
   it('should convert a simple get request with timeout', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[1].request, { requestTimeout: 3 }, function (err, snippet) {
       if (err) {
@@ -35,7 +35,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with formdata', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[4].request, {}, function (err, snippet) {
       if (err) {
@@ -48,7 +48,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with raw data', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[6].request, {}, function (err, snippet) {
       if (err) {
@@ -61,7 +61,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with urlencoded', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[7].request, {}, function (err, snippet) {
       if (err) {
@@ -74,7 +74,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with json with raw', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[8].request, {}, function (err, snippet) {
       if (err) {
@@ -87,7 +87,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with javascript with raw', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[9].request, {}, function (err, snippet) {
       if (err) {
@@ -100,7 +100,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with xml with raw', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[10].request, {}, function (err, snippet) {
       if (err) {
@@ -113,7 +113,7 @@ describe('convert function', function () {
   });
 
   it('should convert a post request with binary file', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     convert(collection.items.members[25].request, {}, function (err, snippet) {
       if (err) {

--- a/codegens/r-httr/test/unit/parseBody.test.js
+++ b/codegens/r-httr/test/unit/parseBody.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path'),
   {
@@ -10,7 +10,7 @@ var expect = require('chai').expect,
 describe('parseBody function', function () {
 
   it('should parse a raw json Body', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body,
       indentation = '  ',
@@ -21,7 +21,7 @@ describe('parseBody function', function () {
   });
 
   it('should parse a raw json Body with indentation', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body,
       indentation = '   ',
@@ -32,7 +32,7 @@ describe('parseBody function', function () {
   });
 
   it('should parse a raw xml Body', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[10].request.body,
       indentation = '   ',
@@ -43,7 +43,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-url-encoded params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[7].request.body,
       indentation = '  ',
@@ -60,7 +60,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-data params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[4].request.body,
       indentation = '  ',
@@ -79,7 +79,7 @@ describe('parseBody function', function () {
   });
 
   it('should return form-data params with a file', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[26].request.body,
       indentation = '  ',
@@ -93,7 +93,7 @@ describe('parseBody function', function () {
   });
 
   it('should return binary data params with a file', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[25].request.body,
       indentation = '  ',
@@ -105,7 +105,7 @@ describe('parseBody function', function () {
   });
 
   it('should return graphql params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[27].request.body,
       indentation = '  ',
@@ -120,7 +120,7 @@ describe('parseBody function', function () {
   });
 
   it('should return empty form data', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[28].request.body,
       indentation = '  ',

--- a/codegens/r-rcurl/test/unit/convert.test.js
+++ b/codegens/r-rcurl/test/unit/convert.test.js
@@ -1,11 +1,11 @@
 var expect = require('chai').expect,
   { convert } = require('../../index'),
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path');
 
 describe('convert function', function () {
-  const collection = new sdk.Collection(JSON.parse(
+  const collection = new Collection(JSON.parse(
     fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
 
   it('should convert requests with default options', function (done) {

--- a/codegens/r-rcurl/test/unit/parseBody.test.js
+++ b/codegens/r-rcurl/test/unit/parseBody.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path'),
   {
@@ -14,7 +14,7 @@ var expect = require('chai').expect,
 
 describe('parseURLEncodedBody method', function () {
   it('should return form-url-encoded params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[7].request.body.urlencoded,
       indentation = '  ',
@@ -41,7 +41,7 @@ describe('parseURLEncodedBody method', function () {
 
 describe('parseFormData method', function () {
   it('should return form data params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[4].request.body.formdata,
       indentation = '  ',
@@ -67,7 +67,7 @@ describe('parseFormData method', function () {
   });
 
   it('should return form data params file', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[26].request.body.formdata,
       indentation = '  ',
@@ -80,7 +80,7 @@ describe('parseFormData method', function () {
 
 describe('parseRawBody method', function () {
   it('should return formData json params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body.raw,
       indentation = '  ',
@@ -95,7 +95,7 @@ describe('parseRawBody method', function () {
 
 describe('parseGraphQL method', function () {
   it('should return graphql json params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[27].request.body.graphql,
       bodyTrim = false,
@@ -110,7 +110,7 @@ describe('parseGraphQL method', function () {
 
 describe('parseBody method', function () {
   it('should return form-url-encoded params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[7].request.body,
       indentation = '  ',
@@ -128,7 +128,7 @@ describe('parseBody method', function () {
   });
 
   it('should return form data params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[4].request.body,
       indentation = '  ',
@@ -146,7 +146,7 @@ describe('parseBody method', function () {
   });
 
   it('should return raw json params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[8].request.body,
       indentation = '  ',
@@ -159,7 +159,7 @@ describe('parseBody method', function () {
   });
 
   it('should return raw string params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[6].request.body,
       indentation = '  ',
@@ -172,7 +172,7 @@ describe('parseBody method', function () {
   });
 
   it('should return graphql params', function () {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
         fs.readFileSync(path.resolve(__dirname, collectionsPath, './sample_collection.json').toString()))),
       body = collection.items.members[27].request.body,
       indentation = '  ',

--- a/codegens/r-rcurl/test/unit/rRcurl.test.js
+++ b/codegens/r-rcurl/test/unit/rRcurl.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
   { Collection } = require('postman-collection/lib/collection/collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   fs = require('fs'),
   path = require('path'),
   {

--- a/codegens/r-rcurl/test/unit/rRcurl.test.js
+++ b/codegens/r-rcurl/test/unit/rRcurl.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
   fs = require('fs'),
   path = require('path'),
   {
@@ -21,7 +21,7 @@ var expect = require('chai').expect,
 describe('convert function', function () {
 
   it('should convert a simple get request', function (done) {
-    const collection = new sdk.Collection(JSON.parse(
+    const collection = new Collection(JSON.parse(
       fs.readFileSync(path.resolve(__dirname, './fixtures/sample_collection.json').toString())));
     collection.items.members.forEach((item) => {
       convert(item.request, { }, function (err, snippet) {
@@ -329,7 +329,7 @@ describe('getSnippetPostFormInOptions method', function () {
 
 describe('addContentTypeHeader method', function () {
   it('should add content type header when is graphql', function () {
-    const request = new sdk.Request({
+    const request = new Request({
       'method': 'POST',
       'header': [
       ],
@@ -350,7 +350,7 @@ describe('addContentTypeHeader method', function () {
   });
 
   it('should not add content type header when is not graphql', function () {
-    const request = new sdk.Request({
+    const request = new Request({
       'method': 'POST',
       'header': [
       ],

--- a/codegens/ruby/test/unit/converter.test.js
+++ b/codegens/ruby/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert;
 
 describe('Ruby converter', function () {
@@ -9,7 +9,7 @@ describe('Ruby converter', function () {
   });
 
   it('should set read_timeout when requestTimeout is set to non zero value', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -32,7 +32,7 @@ describe('Ruby converter', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -59,7 +59,7 @@ describe('Ruby converter', function () {
   });
 
   it('should escape special characters inside double quotes', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [
         'Content-Type: application/json'
@@ -92,7 +92,7 @@ describe('Ruby converter', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {

--- a/codegens/rust-reqwest/test/unit/convert.test.js
+++ b/codegens/rust-reqwest/test/unit/convert.test.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   convert = require('../../lib/index').convert;
 
 describe('Rust reqwest converter', function () {
@@ -9,7 +9,7 @@ describe('Rust reqwest converter', function () {
   });
 
   it('should set no redirect policy when followRedirect is set to false', function () {
-    const request = new sdk.Request({
+    const request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -35,7 +35,7 @@ describe('Rust reqwest converter', function () {
   });
 
   it('should set read timeout when requestTimeout is set to non zero value', function () {
-    const request = new sdk.Request({
+    const request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -62,7 +62,7 @@ describe('Rust reqwest converter', function () {
 
   it('should use the method name directly if it is part of allowed methods', function () {
     ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'CONNECT', 'PATH', 'TRACE'].forEach(function (method) {
-      const request = new sdk.Request({
+      const request = new Request({
           'method': method,
           'header': [],
           'url': {
@@ -90,7 +90,7 @@ describe('Rust reqwest converter', function () {
 
   it('should use the method name using bytes if it not part of the allowed list', function () {
     ['PROPFIND', 'PURGE', 'LOCK', 'UNLOCK', 'LINK', 'UNLINK', 'COPY'].forEach(function (method) {
-      const request = new sdk.Request({
+      const request = new Request({
           'method': method,
           'header': [],
           'url': {

--- a/codegens/shell-httpie/test/unit/converter.test.js
+++ b/codegens/shell-httpie/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   runNewmanTest = require('../../../../test/codegen/newman/newmanTestUtil').runNewmanTest,
   convert = require('../../index').convert,
   sanitize = require('../../lib/util/sanitize').quote;
@@ -18,7 +18,7 @@ describe('Shell-Httpie convert function', function () {
   });
 
   it('should add a timeout of 1 hour (3600 seconds) for RequestTimeout set to 0', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -43,7 +43,7 @@ describe('Shell-Httpie convert function', function () {
   });
 
   it('should add port in the url when host has port specified', function () {
-    var request = new sdk.Request({
+    var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {
@@ -69,7 +69,7 @@ describe('Shell-Httpie convert function', function () {
   });
 
   it('should trim header keys and not trim header values', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [
         {
@@ -96,7 +96,7 @@ describe('Shell-Httpie convert function', function () {
   });
 
   it('should generate snippets for no files in form data', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'POST',
       'header': [],
       'body': {
@@ -145,7 +145,7 @@ describe('Shell-Httpie convert function', function () {
   });
 
   it('should generate valid snippet and should include appropriate variable name', function () {
-    var request = new sdk.Request({
+    var request = new Request({
       'method': 'GET',
       'header': [],
       'body': {},

--- a/codegens/shell-wget/test/unit/converter.test.js
+++ b/codegens/shell-wget/test/unit/converter.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   sanitize = require('../../lib/util/sanitize').sanitize,
   convert = require('../../lib/index').convert,
   getOptions = require('../../lib/index').getOptions,
@@ -9,7 +9,7 @@ describe('Shell-Wget converter', function () {
 
 
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       snippetArray,
       options = {
         indentType: 'Tab',
@@ -82,7 +82,7 @@ describe('Shell-Wget converter', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -110,7 +110,7 @@ describe('Shell-Wget converter', function () {
     });
 
     it('should generate snippet for formdata body mode', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -153,7 +153,7 @@ describe('Shell-Wget converter', function () {
     });
 
     it('should generate valid snippet for single/double quotes in url', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [],
         'url': {

--- a/codegens/swift/test/unit/convert.test.js
+++ b/codegens/swift/test/unit/convert.test.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
+  { Url } = require('postman-collection/lib/collection/url'),
   convert = require('../../index').convert,
   sanitize = require('../../lib/util').sanitize,
   getUrlStringfromUrlObject = require('../../lib/util').getUrlStringfromUrlObject,
@@ -10,7 +11,7 @@ var expect = require('chai').expect,
 describe('Swift Converter', function () {
 
   describe('convert function', function () {
-    var request = new sdk.Request(mainCollection.item[0].request),
+    var request = new Request(mainCollection.item[0].request),
       snippetArray;
 
     const SINGLE_SPACE = ' '; // default indent type with indent count of 2
@@ -31,7 +32,7 @@ describe('Swift Converter', function () {
     });
 
     it('should add content type if formdata field contains a content-type', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'body': {
           'mode': 'formdata',
@@ -95,7 +96,7 @@ describe('Swift Converter', function () {
 
     it('should not encode queryParam unresolved variables and ' +
     'leave it inside double parenthesis {{xyz}}', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -127,7 +128,7 @@ describe('Swift Converter', function () {
     });
 
     it('should encode queryParams other than unresolved variables', function () {
-      request = new sdk.Request({
+      request = new Request({
         'method': 'POST',
         'header': [],
         'url': {
@@ -159,7 +160,7 @@ describe('Swift Converter', function () {
     });
 
     it('should trim header keys and not trim header values', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'GET',
         'header': [
           {
@@ -187,7 +188,7 @@ describe('Swift Converter', function () {
     });
 
     it('should generate snippets for no files in form data', function () {
-      var request = new sdk.Request({
+      var request = new Request({
         'method': 'POST',
         'header': [],
         'body': {
@@ -238,7 +239,7 @@ describe('Swift Converter', function () {
 
     it('should generate valid snippets for single/double quotes in URL', function () {
       // url = https://a"b'c.com/'d/"e
-      var request = new sdk.Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
+      var request = new Request("https://a\"b'c.com/'d/\"e"); // eslint-disable-line quotes
       convert(request, {}, function (error, snippet) {
         if (error) {
           expect.fail(null, null, error);
@@ -254,7 +255,7 @@ describe('Swift Converter', function () {
 
     it('should return empty string for an url object for an empty url or if no url object is passed', function () {
       rawUrl = '';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.be.empty;
       outputUrlString = getUrlStringfromUrlObject();
@@ -263,14 +264,14 @@ describe('Swift Converter', function () {
 
     it('should add protocol if present in the url object', function () {
       rawUrl = 'https://postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add the auth information if present in the url object', function () {
       rawUrl = 'https://user:password@postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
@@ -278,28 +279,28 @@ describe('Swift Converter', function () {
     it('should not add the auth information if user isn\'t present but' +
     ' password is present in the url object', function () {
       rawUrl = 'https://:password@postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.not.include(':password');
     });
 
     it('should add host if present in the url object', function () {
       rawUrl = 'https://postman-echo.com';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add port if present in the url object', function () {
       rawUrl = 'https://postman-echo.com:8080';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
 
     it('should add path if present in the url object', function () {
       rawUrl = 'https://postman-echo.com/get';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });
@@ -308,7 +309,7 @@ describe('Swift Converter', function () {
 
       it('should not encode unresolved query params', function () {
         rawUrl = 'https://postman-echo.com/get?key={{value}}';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.not.include('key=%7B%7Bvalue%7B%7B');
         expect(outputUrlString).to.equal(rawUrl);
@@ -316,7 +317,7 @@ describe('Swift Converter', function () {
 
       it('should encode query params other than unresolved variables', function () {
         rawUrl = 'https://postman-echo.com/get?key=\'a b c\'';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.not.include('key=\'a b c\'');
         expect(outputUrlString).to.equal('https://postman-echo.com/get?key=%27a%20b%20c%27');
@@ -325,7 +326,7 @@ describe('Swift Converter', function () {
       it('should not encode unresolved query params and ' +
       'encode every other query param, both present together', function () {
         rawUrl = 'https://postman-echo.com/get?key1={{value}}&key2=\'a b+c\'';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.not.include('key1=%7B%7Bvalue%7B%7B');
         expect(outputUrlString).to.not.include('key2=\'a b+c\'');
@@ -334,13 +335,13 @@ describe('Swift Converter', function () {
 
       it('should not encode query params that are already encoded', function () {
         rawUrl = 'https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324';
-        urlObject = new sdk.Url(rawUrl);
+        urlObject = new Url(rawUrl);
         outputUrlString = getUrlStringfromUrlObject(urlObject);
         expect(outputUrlString).to.equal('https://postman-echo.com/get?query=urn%3Ali%3Afoo%3A62324');
       });
 
       it('should discard disabled query params', function () {
-        urlObject = new sdk.Url({
+        urlObject = new Url({
           protocol: 'https',
           host: 'postman-echo.com',
           query: [
@@ -355,7 +356,7 @@ describe('Swift Converter', function () {
 
     it('should add hash if present in the url object', function () {
       rawUrl = 'https://postmanm-echo.com/get#hash';
-      urlObject = new sdk.Url(rawUrl);
+      urlObject = new Url(rawUrl);
       outputUrlString = getUrlStringfromUrlObject(urlObject);
       expect(outputUrlString).to.equal(rawUrl);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const sdk = require('postman-collection'),
+const { Request } = require('postman-collection/lib/collection/request'),
   labelList = require('./assets/languageLabels.json'),
   languageMap = require('./assets/languages.js');
 
@@ -86,7 +86,7 @@ module.exports = {
   convert (language, variant, request, options, callback) {
     let convert, main;
 
-    if (!sdk.Request.isRequest(request)) {
+    if (!Request.isRequest(request)) {
       return callback('Codegen~convert: Invalid request');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@faker-js/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw=="
+    },
     "@postman/form-data": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.1.tgz",
@@ -2187,7 +2192,8 @@
     "faker": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -5343,20 +5349,20 @@
       "dev": true
     },
     "postman-collection": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.0.0.tgz",
-      "integrity": "sha512-vDrXG/dclSu6RMqPqBz4ZqoQBwcj/a80sJYsQZmzWJ6dWgXiudPhwu6Vm3C1Hy7zX5W8A6am1Z6vb/TB4eyURA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "requires": {
-        "faker": "5.5.3",
+        "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",
         "http-reasons": "0.1.0",
         "iconv-lite": "0.6.3",
         "liquid-json": "0.3.1",
         "lodash": "4.17.21",
         "mime-format": "2.0.1",
-        "mime-types": "2.1.31",
-        "postman-url-encoder": "3.0.1",
-        "semver": "7.3.5",
+        "mime-types": "2.1.35",
+        "postman-url-encoder": "3.0.5",
+        "semver": "7.5.4",
         "uuid": "8.3.2"
       },
       "dependencies": {
@@ -5377,22 +5383,22 @@
           }
         },
         "mime-db": {
-          "version": "1.48.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-          "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.31",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-          "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.48.0"
+            "mime-db": "1.52.0"
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -5685,17 +5691,17 @@
       }
     },
     "postman-url-encoder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.1.tgz",
-      "integrity": "sha512-dMPqXnkDlstM2Eya+Gw4MIGWEan8TzldDcUKZIhZUsJ/G5JjubfQPhFhVWKzuATDMvwvrWbSjF+8VmAvbu6giw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.5.tgz",
+      "integrity": "sha512-jOrdVvzUXBC7C+9gkIkpDJ3HIxOHTIqjpQ4C1EMt1ZGeMvSEpbFCKq23DEfgsj46vMnDgyQf+1ZLp2Wm+bKSsA==",
       "requires": {
         "punycode": "^2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "4.17.21",
     "async": "3.2.2",
     "path": "0.12.7",
-    "postman-collection": "4.0.0",
+    "postman-collection": "^4.4.0",
     "shelljs": "0.8.5"
   },
   "devDependencies": {

--- a/test/codegen/newman/fixtures/formdataFileCollection.json
+++ b/test/codegen/newman/fixtures/formdataFileCollection.json
@@ -17,15 +17,15 @@
               "key": "single file",
               "value": "",
               "type": "file",
-              "src": "/Users/amansingh/workspace/postman-code-generators/dummyFile1.txt"
+              "src": "/Users/vishalkumar.shingala@postman.com/pm/postman-code-generators/dummyFile1.txt"
             },
             {
               "key": "multiple files",
               "value": "",
               "type": "file",
               "src": [
-                "/Users/amansingh/workspace/postman-code-generators/dummyFile2.txt",
-                "/Users/amansingh/workspace/postman-code-generators/dummyFile3.txt"
+                "/Users/vishalkumar.shingala@postman.com/pm/postman-code-generators/dummyFile2.txt",
+                "/Users/vishalkumar.shingala@postman.com/pm/postman-code-generators/dummyFile3.txt"
               ]
             }
           ]
@@ -55,7 +55,7 @@
               "key": "binary file",
               "value": "",
               "type": "file",
-              "src": "/Users/amansingh/workspace/postman-code-generators/dummyBinaryFile"
+              "src": "/Users/vishalkumar.shingala@postman.com/pm/postman-code-generators/dummyBinaryFile"
             }
           ]
         },

--- a/test/codegen/newman/newmanTestUtil.js
+++ b/test/codegen/newman/newmanTestUtil.js
@@ -1,7 +1,7 @@
 var fs = require('fs'),
   expect = require('chai').expect,
   exec = require('shelljs').exec,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   path = require('path'),
   newmanResponses = require('./newmanResponses.json'),
   async = require('async');
@@ -179,7 +179,7 @@ module.exports = {
         // Convert code snippet
         var collection = require(collectionObj.path);
         async.map(collection.item, function (item, cb) {
-          var request = new sdk.Request(item.request);
+          var request = new Request(item.request);
 
           convert(request, options, function (err, snippet) {
             if (err) {

--- a/test/codegen/sanity/sanity.test.js
+++ b/test/codegen/sanity/sanity.test.js
@@ -1,5 +1,5 @@
 var expect = require('chai').expect,
-  sdk = require('postman-collection'),
+  { Request } = require('postman-collection/lib/collection/request'),
   path = require('path'),
   fs = require('fs'),
   args = process.argv.splice(2),
@@ -15,7 +15,7 @@ describe('Sanity tests for ' + codegen, function () {
     collection = JSON.parse(collection);
 
     collection.item.forEach((item) => {
-      var request = new sdk.Request(item.request);
+      var request = new Request(item.request);
       it('should generate snippet for ' + collectionName.split('.')[0] + ' request: ' + item.name, function (done) {
         converter.convert(request, {}, function (error, snippet) {
           if (error) {

--- a/test/codegen/structure.test.js
+++ b/test/codegen/structure.test.js
@@ -168,11 +168,10 @@ describe('Code-gen repository ' + codegen, function () {
         expect(json.dependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.dependencies && Object.keys(json.dependencies).forEach(function (item) {
-          expect(json.dependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$')); // eslint-disable-line max-len
-        });
+      it('should have a valid version string in form of <major>.<minor>.<revision>', function () {
+        expect(json.version)
+          // eslint-disable-next-line max-len, security/detect-unsafe-regex
+          .to.match(/^((\d+)\.(\d+)\.(\d+))(?:-([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?$/);
       });
     });
 
@@ -181,10 +180,11 @@ describe('Code-gen repository ' + codegen, function () {
         expect(json.devDependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.devDependencies && Object.keys(json.devDependencies).forEach(function (item) {
-          expect(json.devDependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$')); // eslint-disable-line max-len
+      it('should point to a valid semver', function () {
+        Object.keys(json.devDependencies).forEach(function (dependencyName) {
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          expect(json.devDependencies[dependencyName]).to.match(new RegExp('((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
+            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
         });
       });
 

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -53,11 +53,10 @@ describe('project repository', function () {
         expect(json.dependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.dependencies && Object.keys(json.dependencies).forEach(function (item) {
-          expect(json.dependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-                        '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
-        });
+      it('should have a valid version string in form of <major>.<minor>.<revision>', function () {
+        expect(json.version)
+          // eslint-disable-next-line max-len, security/detect-unsafe-regex
+          .to.match(/^((\d+)\.(\d+)\.(\d+))(?:-([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?$/);
       });
     });
 
@@ -66,10 +65,11 @@ describe('project repository', function () {
         expect(json.devDependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        json.devDependencies && Object.keys(json.devDependencies).forEach(function (item) {
-          expect(json.devDependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-                        '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
+      it('should point to a valid semver', function () {
+        Object.keys(json.devDependencies).forEach(function (dependencyName) {
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          expect(json.devDependencies[dependencyName]).to.match(new RegExp('((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
+            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
         });
       });
 


### PR DESCRIPTION
## Overview

This PR updates "postman-collection" version used to latest. We're also now making sure that we're only requiring the part of SDK that's used in codebase by requiring specific files.


This means if we use say `Response` from `postman-collection` module then instead of requiring it like below,

```
const { Response } = require('postman-collection');
```

we will be requiring Response from specific module exporting it like below.

```
const { Response } = require('postman-collection/lib/collection/response');
```