### PR TITLE
Fixed an issue where io package was declared twice.

### DIFF
--- a/codegens/golang/lib/index.js
+++ b/codegens/golang/lib/index.js
@@ -238,7 +238,7 @@ self = module.exports = {
     }
     if (isFile) {
       codeSnippet += `${indent}"os"\n${indent}"path/filepath"\n`;
-      codeSnippet += `${indent}"io"\n`;
+
       // Setting isFile as false for further calls to this function
       isFile = false;
     }


### PR DESCRIPTION
## Overview

This PR fixes one of a missed declaration removal that was introduced with https://github.com/postmanlabs/postman-code-generators/pull/721

i.e. Since we're now declaring `io` at global level, we don not need to redeclare it for input type of file specifically. Tests that were failing were due to this reason.