### PR TITLE
Update deepinstall.js to fix pnpm install

### DIFF
--- a/npm/deepinstall.js
+++ b/npm/deepinstall.js
@@ -48,7 +48,7 @@ async.series([
           }
           break;
         case 'pnpm':
-          command = 'pnpm install --prod';
+          command = 'pnpm install --ignore-workspace --prod';
           break;
         default:
           command = pm + ' install --no-audit --production';


### PR DESCRIPTION
`pnpm install` from a subproject in a project with a `pnpm-workspace.yaml` installs the workspaces' dependencies, not the subproject even if that subproject is not part of the workspace. That is causing the postinstall script to hang in some cases. This change tells `pnpm` to ignore the parent workspace making it work as expected.

Closes #772 

See: https://github.com/pnpm/pnpm/issues/2412