### PR TITLE
remove extra line

### DIFF
--- a/codegens/csharp-httpclient/lib/CodeBuilder.js
+++ b/codegens/csharp-httpclient/lib/CodeBuilder.js
@@ -70,7 +70,7 @@ class CodeBuilder {
       extra = '';
     }
     this.currentIndentCount--;
-    this.snippet += this.indentation + '}' + extra + this.newLineChar;
+    this.snippet += this.indentation + '}' + extra;
   }
 
   /**

--- a/codegens/dart-http/lib/index.js
+++ b/codegens/dart-http/lib/index.js
@@ -216,7 +216,7 @@ self = module.exports = {
       }
       headerSnippet += 'import \'package:http/http.dart\' as http;\n\n';
       headerSnippet += 'void main() async {\n';
-      footerSnippet = '}\n';
+      footerSnippet = '}';
     }
 
     // The following code handles multiple files in the same formdata param.

--- a/codegens/java-unirest/lib/unirest.js
+++ b/codegens/java-unirest/lib/unirest.js
@@ -92,7 +92,7 @@ function makeSnippet (request, indentString, options) {
     });
   }
   snippet += parseRequest.parseBody(request, indentString, options.trimRequestBody);
-  snippet += indentString + '.asString();\n';
+  snippet += indentString + '.asString();';
 
   return snippet;
 }

--- a/codegens/libcurl/lib/index.js
+++ b/codegens/libcurl/lib/index.js
@@ -218,7 +218,7 @@ self = module.exports = {
       snippet += indentString + 'curl_slist_free_all(headers);\n';
     }
     snippet += '}\n';
-    snippet += 'curl_easy_cleanup(curl);\n';
+    snippet += 'curl_easy_cleanup(curl);';
     (options.includeBoilerplate) &&
     (snippet = indentString + snippet.split('\n').join('\n' + indentString));
     callback(null, headerSnippet + snippet + footerSnippet);

--- a/codegens/nodejs-axios/lib/axios.js
+++ b/codegens/nodejs-axios/lib/axios.js
@@ -136,7 +136,7 @@ function makeSnippet (request, indentString, options) {
     snippet += indentString.repeat(2) + 'console.log(error);\n';
     snippet += indentString + '}\n';
     snippet += '}\n\n';
-    snippet += 'makeRequest();\n';
+    snippet += 'makeRequest();';
   }
   else {
     snippet += 'axios.request(config)\n';
@@ -145,7 +145,7 @@ function makeSnippet (request, indentString, options) {
     snippet += '})\n';
     snippet += '.catch((error) => {\n';
     snippet += indentString + 'console.log(error);\n';
-    snippet += '});\n';
+    snippet += '});';
   }
 
   return snippet;

--- a/codegens/nodejs-request/lib/request.js
+++ b/codegens/nodejs-request/lib/request.js
@@ -98,7 +98,7 @@ function makeSnippet (request, indentString, options) {
   }
   snippet += indentString + 'if (error) throw new Error(error);\n';
   snippet += indentString + 'console.log(response.body);\n';
-  snippet += '});\n';
+  snippet += '});';
   return snippet;
 }
 

--- a/codegens/nodejs-unirest/lib/unirest.js
+++ b/codegens/nodejs-unirest/lib/unirest.js
@@ -105,7 +105,7 @@ function makeSnippet (request, indentString, options) {
   }
   snippet += indentString.repeat(2) + 'if (res.error) throw new Error(res.error); \n';
   snippet += indentString.repeat(2) + 'console.log(res.raw_body);\n';
-  snippet += indentString + '});\n';
+  snippet += indentString + '});';
 
   return snippet;
 }

--- a/codegens/php-curl/lib/php-curl.js
+++ b/codegens/php-curl/lib/php-curl.js
@@ -178,7 +178,7 @@ self = module.exports = {
     snippet += '));\n\n';
     snippet += '$response = curl_exec($curl);\n\n';
     snippet += 'curl_close($curl);\n';
-    snippet += 'echo $response;\n';
+    snippet += 'echo $response;';
 
     return callback(null, snippet);
   }

--- a/codegens/php-guzzle/lib/phpGuzzle.js
+++ b/codegens/php-guzzle/lib/phpGuzzle.js
@@ -163,7 +163,7 @@ function getSnippetFooterSync (includeRequestOptions) {
     'echo $res->getBody();\n';
   }
   return '$res = $client->send($request, $options);\n' +
-  'echo $res->getBody();\n';
+  'echo $res->getBody();';
 }
 
 /**
@@ -179,7 +179,7 @@ function getSnippetFooterAsync (includeRequestOptions) {
     'echo $res->getBody();\n';
   }
   return '$res = $client->sendAsync($request, $options)->wait();\n' +
-  'echo $res->getBody();\n';
+  'echo $res->getBody();';
 }
 
 /**

--- a/codegens/php-pecl-http/lib/phpPecl.js
+++ b/codegens/php-pecl-http/lib/phpPecl.js
@@ -175,7 +175,7 @@ self = module.exports = {
     snippet += `${getHeaders(request, indentation)}\n`;
     snippet += '$client->enqueue($request)->send();\n';
     snippet += '$response = $client->getResponse();\n';
-    snippet += 'echo $response->getBody();\n';
+    snippet += 'echo $response->getBody();';
 
     return callback(null, snippet);
   }

--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -179,7 +179,7 @@ self = module.exports = {
     snippet += !options.followRedirect ? ', allow_redirects=False' : '';
     snippet += options.requestTimeout !== 0 ? `, timeout=${options.requestTimeout}` : '';
     snippet += ')\n\n';
-    snippet += 'print(response.text)\n';
+    snippet += 'print(response.text)';
 
     callback(null, snippet);
   }

--- a/codegens/ruby/lib/ruby.js
+++ b/codegens/ruby/lib/ruby.js
@@ -197,7 +197,7 @@ self = module.exports = {
       }
       snippet += `${parseBody(request.toJSON(), options.trimRequestBody, contentType, options.indentCount)}\n`;
       snippet += 'response = https.request(request)\n';
-      snippet += 'puts response.read_body\n';
+      snippet += 'puts response.read_body';
     }
     else {
       snippet += 'http = Net::HTTP.new(url.host, url.port);\n';
@@ -226,7 +226,7 @@ self = module.exports = {
       }
       snippet += `${parseBody(request.toJSON(), options.trimRequestBody, contentType, options.indentCount)}\n`;
       snippet += 'response = http.request(request)\n';
-      snippet += 'puts response.read_body\n';
+      snippet += 'puts response.read_body';
     }
 
     return callback(null, snippet);

--- a/codegens/swift/lib/swift.js
+++ b/codegens/swift/lib/swift.js
@@ -387,7 +387,7 @@ self = module.exports = {
     codeSnippet += `${indent}print(String(data: data, encoding: .utf8)!)\n`;
     codeSnippet += options.includeBoilerplate ? `${indent}exit(EXIT_SUCCESS)\n` : '';
     codeSnippet += '}\n\n';
-    codeSnippet += 'task.resume()\n';
+    codeSnippet += 'task.resume()' + options.includeBoilerplate ? '\n' : '';
     codeSnippet += options.includeBoilerplate ? 'dispatchMain()\n' : '';
 
     return callback(null, codeSnippet);


### PR DESCRIPTION
Closes #682 

I have removed the code responsible for appending extra line in the code generated for the following languages

- C# - HttpClient
- Dart - http
- Java - Unirest
- C - libcurl
- NodeJs - Axios
- NodeJs - Request
- NodeJs - Unirest
- PHP - cURL
- PHP - Guzzle
- PHP - pecl_http
- Python - Requests
- Ruby - NetHTTP
- Swift - URLSession