### PR TITLE
ci: update GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
                    'shell-httpie', 'shell-wget', 'swift' ]
     steps:
       - name: Get Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node JS ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install package dependencies


### PR DESCRIPTION
Updates deprecated GitHub Actions to their latest stable versions:
- actions/checkout@v3  v4
- actions/setup-node@v1  v4

These updates provide better performance and security while maintaining complete backward compatibility with existing workflow configuration. No changes to job logic, build matrix, or test execution.