### PR TITLE
refactor: replace deprecated ESLint CLIEngine with modern ESLint class

### DIFF
--- a/npm/test-lint.js
+++ b/npm/test-lint.js
@@ -3,7 +3,7 @@ require('shelljs/global');
 
 var chalk = require('chalk'),
   async = require('async'),
-  ESLintCLIEngine = require('eslint').CLIEngine,
+  { ESLint } = require('eslint'),
 
   /**
      * The list of source code files / directories to be linted.
@@ -29,8 +29,14 @@ module.exports = function (exit) {
          * @param {Function} next - The callback function whose invocation marks the end of the lint test run.
          * @returns {*}
          */
-    function (next) {
-      next(null, (new ESLintCLIEngine()).executeOnFiles(LINT_SOURCE_DIRS));
+    async function (next) {
+      const eslint = new ESLint();
+      try {
+        const results = await eslint.lintFiles(LINT_SOURCE_DIRS);
+        next(null, { results });
+      } catch (error) {
+        next(error);
+      }
     },
 
     /**
@@ -41,14 +47,19 @@ module.exports = function (exit) {
          * @param {Function} next - The callback whose invocation marks the completion of the post run tasks.
          * @returns {*}
          */
-    function (report, next) {
-      var errorReport = ESLintCLIEngine.getErrorResults(report.results);
-      // log the result to CLI
-      console.info(ESLintCLIEngine.getFormatter()(report.results));
-      // log the success of the parser if it has no errors
-      (errorReport && !errorReport.length) && console.info(chalk.green('eslint ok!'));
-      // ensure that the exit code is non zero in case there was an error
-      next(Number(errorReport && errorReport.length) || 0);
+    async function (report, next) {
+      try {
+        var errorReport = ESLint.getErrorResults(report.results);
+        // log the result to CLI
+        const formatter = await ESLint.loadFormatter();
+        console.info(formatter.format(report.results));
+        // log the success of the parser if it has no errors
+        (errorReport && !errorReport.length) && console.info(chalk.green('eslint ok!'));
+        // ensure that the exit code is non zero in case there was an error
+        next(Number(errorReport && errorReport.length) || 0);
+      } catch (error) {
+        next(error);
+      }
     }
   ], exit);
 };


### PR DESCRIPTION
Replaces the deprecated CLIEngine class with the modern ESLint class in the main lint testing script. CLIEngine has been deprecated since ESLint 7.0, and this update uses the recommended replacement API while preserving identical linting behavior, error reporting, and output formatting. No changes to lint rules or test execution logic.