### PR TITLE
chore: Update ubuntu version used in CI to v22 as ubuntu v20 is deprecated by GH Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
   Unit-Tests:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       max-parallel: 10
       matrix:
         node-version: [ 20.x ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Unit-Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 10
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 20.x ]
         language-variant: [ 'csharp-httpclient', 'csharp-restsharp', 'curl', 'dart-dio', 'dart-http', 'golang', 'http',
                    'java-okhttp', 'java-unirest', 'js-fetch', 'js-jquery', 'js-xhr', 'kotlin-okhttp', 'libcurl',
                    'nodejs-axios', 'nodejs-native', 'nodejs-request', 'nodejs-unirest', 'objective-c', 'ocaml-cohttp',

--- a/codegens/csharp-httpclient/test/ci-install.sh
+++ b/codegens/csharp-httpclient/test/ci-install.sh
@@ -5,7 +5,7 @@ sudo apt-get update
 echo "Installing dependencies required for tests in codegens/csharp-httpclient"
 # Install latest .net6.0 sdk
 pushd ./codegens/csharp-httpclient &>/dev/null;
-  wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+  wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
   sudo dpkg -i packages-microsoft-prod.deb
   sudo apt-get install apt-transport-https
   sudo apt-get update

--- a/codegens/csharp-httpclient/test/ci-install.sh
+++ b/codegens/csharp-httpclient/test/ci-install.sh
@@ -3,13 +3,13 @@ set -ev; # stop on error
 
 sudo apt-get update
 echo "Installing dependencies required for tests in codegens/csharp-httpclient"
-# Install latest .net6.0 sdk
+# Install latest .net8.0 sdk
 pushd ./codegens/csharp-httpclient &>/dev/null;
   wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
   sudo dpkg -i packages-microsoft-prod.deb
   sudo apt-get install apt-transport-https
   sudo apt-get update
-  sudo apt-get install dotnet-sdk-6.0
-  dotnet new console -o testProject -f net6.0
+  sudo apt-get install dotnet-sdk-8.0
+  dotnet new console -o testProject -f net8.0
   # no extra packages needed
 popd &>/dev/null;

--- a/codegens/csharp-restsharp/test/ci-install.sh
+++ b/codegens/csharp-restsharp/test/ci-install.sh
@@ -4,7 +4,7 @@ set -ev; # stop on error
 sudo apt-get update
 echo "Installing dependencies required for tests in codegens/csharp-restsharp"
 pushd ./codegens/csharp-restsharp &>/dev/null;
-  wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+  wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
   sudo dpkg -i packages-microsoft-prod.deb
   sudo apt-get install apt-transport-https
   sudo apt-get update

--- a/codegens/csharp-restsharp/test/ci-install.sh
+++ b/codegens/csharp-restsharp/test/ci-install.sh
@@ -8,8 +8,8 @@ pushd ./codegens/csharp-restsharp &>/dev/null;
   sudo dpkg -i packages-microsoft-prod.deb
   sudo apt-get install apt-transport-https
   sudo apt-get update
-  sudo apt-get install dotnet-sdk-6.0
-  dotnet new console -o testProject -f net6.0
+  sudo apt-get install dotnet-sdk-8.0
+  dotnet new console -o testProject -f net8.0
   pushd ./testProject &>/dev/null;
   dotnet add package RestSharp --version 112.0.0
   popd &>/dev/null;


### PR DESCRIPTION
Ubuntu 20.04 runners were deprecated by GitHub Actions and are no longer available. As of 2024-2025, GitHub only supports:

ubuntu-22.04 (LTS)
ubuntu-24.04 (Latest LTS)

As 22.04 is current `ubuntu-latest`, we're moving to v22 wtih this change.