### PR TITLE
Fix postinstall script to support non-Yarn package managers

### DIFF
--- a/npm/deepinstall.js
+++ b/npm/deepinstall.js
@@ -9,7 +9,7 @@ var shell = require('shelljs'),
   fs = require('fs'),
   pwd = shell.pwd(),
   // eslint-disable-next-line no-process-env
-  initPwd = process.env.INIT_CWD;
+  initCwd = process.env.INIT_CWD;
 const args = process.argv,
   PATH_TO_CODEGENS_FOLDER = path.resolve(__dirname, '../codegens');
 
@@ -21,7 +21,7 @@ getSubfolders = (folder) => {
 
 async.series([
   function (next) {
-    detect({ cwd: initPwd }).then((res) => {
+    detect({ cwd: initCwd }).then((res) => {
       pm = res;
       console.log('Detected package manager: ' + pm);
       return next();

--- a/npm/deepinstall.js
+++ b/npm/deepinstall.js
@@ -7,7 +7,9 @@ var shell = require('shelljs'),
   command,
   getSubfolders,
   fs = require('fs'),
-  pwd = shell.pwd();
+  pwd = shell.pwd(),
+  // eslint-disable-next-line no-process-env
+  initPwd = process.env.INIT_CWD;
 const args = process.argv,
   PATH_TO_CODEGENS_FOLDER = path.resolve(__dirname, '../codegens');
 
@@ -19,7 +21,7 @@ getSubfolders = (folder) => {
 
 async.series([
   function (next) {
-    detect().then((res) => {
+    detect({ cwd: initPwd }).then((res) => {
       pm = res;
       console.log('Detected package manager: ' + pm);
       return next();


### PR DESCRIPTION
## Description

Fixes #792

This PR resolves an issue where the postinstall script fails when using package managers other than Yarn (such as pnpm or npm) in environments where Yarn is also installed globally.

## Problem

The current postinstall script in `npm/postinstall.js` attempts to detect the package manager being used, but fails to properly identify non-Yarn package managers when Yarn is installed globally. This causes the installation to fail with errors when users try to install `postman-code-generators` using pnpm or npm.

## Solution

Set the `INIT_CWD` environment variable during package manager detection to ensure the script correctly identifies the package manager being used, regardless of whether Yarn is installed globally.

## Reproduction Steps (Before Fix)

1. Create a Dockerfile with the following content: 

```dockerfile
FROM node:24.12.0

RUN npm install -g pnpm@10.26.2
RUN npm install -g yarn || true

WORKDIR /app

RUN pnpm init
# For demonstration only—enables 'dangerously-allow-all-builds', which is unsafe in production.
RUN echo "dangerously-allow-all-builds=true" >> .npmrc

# This step is expected to fail
RUN pnpm add postman-code-generators

CMD [ "echo", "Setup Complete" ]
```

2. Run the following command to build: 

```bash
docker build -t bug .
```

**Result:** The build fails when trying to install `postman-code-generators` with pnpm.
