### PR TITLE
Fix multipart/form-data codegen missing --form flag for file fields

### DIFF
--- a/codegens/postman-cli/lib/index.js
+++ b/codegens/postman-cli/lib/index.js
@@ -217,16 +217,15 @@ function addFormDataBody (snippet, body, opts) {
     }
 
     if (data.type === 'file') {
-      const sanitizedSrc = sanitize(data.src, opts.trim, '"', true),
-        wrappedSrc = `@"${sanitizedSrc}"`,
-        finalSrc = sanitize(wrappedSrc, opts.trim, opts.quoteType, opts.quoteType === '"');
-      snippet += ` ${opts.quoteType}${sanitize(data.key, opts.trim, opts.quoteType)}=${finalSrc}`;
+      const sanitizedSrc = sanitize(data.src, opts.trim, opts.quoteType);
+      snippet += `${opts.indent}${form('-f', opts.format)} ` +
+        `${opts.quoteType}${sanitize(data.key, opts.trim, opts.quoteType)}=@${sanitizedSrc}`;
       snippet += opts.quoteType;
     }
     else {
       const sanitizedValue = sanitize(data.value, opts.trim, '"', true),
         finalValue = sanitize(sanitizedValue, opts.trim, opts.quoteType, opts.quoteType === '"');
-      snippet += `${opts.indent} ${form('-f', opts.format)} ` +
+      snippet += `${opts.indent}${form('-f', opts.format)} ` +
         `${opts.quoteType}${sanitize(data.key, opts.trim, opts.quoteType)}=${finalValue}`;
       snippet += opts.quoteType;
     }

--- a/codegens/postman-cli/test/unit/convert.test.js
+++ b/codegens/postman-cli/test/unit/convert.test.js
@@ -479,9 +479,54 @@ describe('postman-cli convert function', function () {
           expect.fail(null, null, error);
         }
         expect(snippet).to.be.a('string');
-        expect(snippet).to.include('\'no file=@"/path/to/file"\'');
-        expect(snippet).to.include('\'no src=@"/path/to/file"\'');
-        expect(snippet).to.include('\'invalid src=@"/path/to/file"\'');
+        expect(snippet).to.include('--form \'no file=@/path/to/file\'');
+        expect(snippet).to.include('--form \'no src=@/path/to/file\'');
+        expect(snippet).to.include('--form \'invalid src=@/path/to/file\'');
+      });
+    });
+
+    it('should generate correct --form flag for each field in multipart/form-data with text and file', function () {
+      var request = new Request({
+        'method': 'POST',
+        'header': [],
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'textField',
+              'value': '123',
+              'type': 'text'
+            },
+            {
+              'key': 'fileField',
+              'value': '',
+              'type': 'file',
+              'src': '/path/to/document.pdf'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'https://postman-echo.com/post',
+          'protocol': 'https',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        // Each field should have its own --form flag
+        expect(snippet).to.include('--form \'textField=');
+        expect(snippet).to.include('--form \'fileField=@/path/to/document.pdf\'');
+        // File path should NOT have inner double quotes
+        expect(snippet).to.not.include('@"/path/to/document.pdf"');
       });
     });
 


### PR DESCRIPTION
This pull request updates the handling and testing of multipart/form-data fields in the Postman CLI code generation logic. The main focus is on improving how file fields are represented in generated CLI snippets and ensuring that both text and file fields are correctly converted.

**Multipart/form-data handling improvements:**

* Updated `addFormDataBody` in `codegens/postman-cli/lib/index.js` to generate CLI snippets using the correct `--form` flag format for file uploads, removing unnecessary inner double quotes around file paths.

**Testing enhancements:**

* Modified existing tests in `codegens/postman-cli/test/unit/convert.test.js` to expect the new `--form` flag format and verify the absence of inner double quotes for file paths.
* Added a new test to ensure that each field (both text and file) in a multipart/form-data request is represented with its own `--form` flag, and that file paths are formatted correctly without extra quotes.