### PR TITLE
Make Python GraphQL snippets more readable and ensure json is imported

### DIFF
--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -113,7 +113,7 @@ self = module.exports = {
     }
     // For GraphQL requests, the payload is always JSON-encoded in the generated snippet,
     // so ensure the json module is imported even if the Content-Type header was not set.
-    if (request.body && request.body.mode === 'graphql') {
+    else if (request.body && request.body.mode === 'graphql') {
       snippet += 'import json\n';
     }
 

--- a/codegens/python-requests/lib/python-requests.js
+++ b/codegens/python-requests/lib/python-requests.js
@@ -111,6 +111,11 @@ self = module.exports = {
     if (contentType && (contentType === 'application/json' || contentType.match(/\+json$/))) {
       snippet += 'import json\n';
     }
+    // For GraphQL requests, the payload is always JSON-encoded in the generated snippet,
+    // so ensure the json module is imported even if the Content-Type header was not set.
+    if (request.body && request.body.mode === 'graphql') {
+      snippet += 'import json\n';
+    }
 
     snippet += '\n';
     snippet += `url = "${sanitize(request.url.toString(), 'url')}"\n\n`;

--- a/codegens/python-requests/lib/util/parseBody.js
+++ b/codegens/python-requests/lib/util/parseBody.js
@@ -156,11 +156,14 @@ module.exports = function (request, indentation, bodyTrim, contentType) {
         catch (e) {
           graphqlVariables = {};
         }
-        requestBody += `payload = ${sanitize(JSON.stringify({
-          query: query,
-          variables: graphqlVariables
-        }),
-        'raw', bodyTrim)}\n`;
+        requestBody += `query = """${query}"""\n`;
+        requestBody += `variables = ${pythonify(graphqlVariables, indentation.length)}\n`;
+        requestBody += 'payload = json.dumps({\n\t"query" : query,\n\t"variables" : variables\n})\n';
+        // requestBody += `payload = ${sanitize(JSON.stringify({
+        //   query: query,
+        //   variables: graphqlVariables
+        // }),
+        // 'raw', bodyTrim)}\n`;
         return requestBody;
       case 'urlencoded':
         enabledBodyList = _.reject(request.body[request.body.mode], 'disabled');


### PR DESCRIPTION
# Make Python GraphQL snippets more readable and fix `json` import

## This PR solves the #813 

This PR updates the `python-requests` code generator for GraphQL requests to:

- Generate clearer Python snippets where the GraphQL **query** and **variables** are separate variables, and
- Always include `import json` when GraphQL payloads use `json.dumps`.

## Changes

- **`codegens/python-requests/lib/util/parseBody.js`**
  - In the `graphql` branch:
    - Emit a triple-quoted `query` variable.
    - Convert GraphQL variables to a Python structure (`variables`) using the existing helper.
    - Build `payload` as:

      ```python
      payload = json.dumps({
          "query": query,
          "variables": variables
      })
      ```

- **`codegens/python-requests/lib/python-requests.js`**
  - Keep the existing logic that imports `json` for JSON `Content-Type`.
  - Additionally import `json` whenever `request.body.mode === 'graphql'` so GraphQL snippets can always call `json.dumps` safely.

## Rationale

Previously, the GraphQL query and variables effectively ended up inside a single JSON string, which made the generated snippet hard to read and edit.  
In some GraphQL cases, `json.dumps` was used without `import json`, causing `NameError: name 'json' is not defined`.  
These changes address both readability and that runtime error.

## Testing

- `npm test python-requests`
  - ESLint: no new errors (only existing warnings remain).
  - Newman + Mocha tests for `python-requests` pass, including the GraphQL case (`POST graphql body(json) with raw`).
  - Manually verified that the generated GraphQL Python snippet now has `query`, `variables`, `payload` as described above, and includes `import json`.

