### PR TITLE
Honor contentType on file-type FormParams in curl codegen

### DIFF
--- a/codegens/curl/lib/index.js
+++ b/codegens/curl/lib/index.js
@@ -197,6 +197,9 @@ self = module.exports = {
                   snippet += indent + `${form('-F', format)}`;
                   snippet += ` ${quoteType}${sanitize(data.key, trim, quoteType)}=` +
                     `${sanitize(`@"${sanitize(data.src, trim, '"', true)}"`, trim, quoteType, quoteType === '"')}`;
+                  if (data.contentType) {
+                    snippet += `;type=${data.contentType}`;
+                  }
                   snippet += quoteType;
                 }
                 else {

--- a/codegens/curl/test/unit/convert.test.js
+++ b/codegens/curl/test/unit/convert.test.js
@@ -163,6 +163,41 @@ describe('curl convert function', function () {
       });
     });
 
+    it('should add content type if formdata file field contains a content-type', function () {
+      request = new Request({
+        'method': 'POST',
+        'body': {
+          'mode': 'formdata',
+          'formdata': [
+            {
+              'key': 'attachment',
+              'src': '/path/to/file.png',
+              'contentType': 'image/png',
+              'type': 'file'
+            }
+          ]
+        },
+        'url': {
+          'raw': 'http://postman-echo.com/post',
+          'host': [
+            'postman-echo',
+            'com'
+          ],
+          'path': [
+            'post'
+          ]
+        }
+      });
+
+      convert(request, {}, function (error, snippet) {
+        if (error) {
+          expect.fail(null, null, error);
+        }
+        expect(snippet).to.be.a('string');
+        expect(snippet).to.contain('--form \'attachment=@"/path/to/file.png";type=image/png\'');
+      });
+    });
+
     it('should add content type if formdata field contains a content-type', function () {
       request = new Request({
         'method': 'POST',


### PR DESCRIPTION

Closes [#815](https://github.com/postmanlabs/postman-code-generators/issues/815)

The curl codegen threads `contentType` through preprocessing for `type === 'file'` FormParams (around `codegens/curl/lib/index.js:107`), but snippet generation only applied the `;type=<ct>` suffix in the text-type branch. File-type
  form parts always rendered without `;type=`, even when `contentType` was set.

  Mirrors the same check into the file-type branch so generated snippets emit `-F 'attachment=@"/path/to/file";type=image/png'` when contentType is present. curl supports `;type=` for file parts identically to text parts.

  **Context**

  Surfaced in PaloAltoNetworks/docusaurus-openapi-docs#1369 (merged), which adds OpenAPI `encoding.contentType` support for `multipart/form-data` parts. That PR threads `contentType` onto each `sdk.FormParam` per the OAS spec — for text
   parts the snippet picks it up, for binary file parts it drops it. Their PR explicitly documents this as a "Known limitation" pending an upstream fix here. This PR is that upstream fix.

  **Test**

  Regression test in `codegens/curl/test/unit/convert.test.js` mirrors the existing text-type contentType test but with `type: 'file'`. Full curl suite green (50 → 51 passing). Lint clean on changed files.